### PR TITLE
[仕様検討] JSON/CSV出力スキーマを確定

### DIFF
--- a/docs/03_仕様書.md
+++ b/docs/03_仕様書.md
@@ -344,6 +344,45 @@
 - `text_type` は将来的に「通常テロップ」「人物名」「見出し」などの分類へ拡張可能とする。
 
 ## 8. JSON 出力スキーマ案
+### 8.1 基本方針
+- JSON は機械可読な完全出力とする。
+- フレーム単位情報とセグメント単位情報を同一ファイルで保持できる構成とする。
+- 将来拡張のため、トップレベルに `schema_version` を必須とする。
+- 不明値は `null` を使用し、未定義項目の省略は原則行わない。
+
+### 8.2 トップレベル構造
+- `schema_version`
+- `source_video`
+- `processing_settings`
+- `frames`
+- `segments`
+- `run_metadata`
+
+### 8.3 トップレベル項目定義
+- `schema_version`
+  - 型: `string`
+  - 例: `1.0.0`
+- `source_video`
+  - 型: `object`
+  - 内容: 入力動画のメタデータ
+- `processing_settings`
+  - 型: `object`
+  - 内容: 抽出設定、OCR 設定、実行条件
+- `frames`
+  - 型: `array`
+  - 内容: フレーム単位解析結果
+- `segments`
+  - 型: `array`
+  - 内容: 統合済みテロップ単位解析結果
+- `run_metadata`
+  - 型: `object`
+  - 内容: 実行ログ要約、生成日時、アプリバージョンなど
+
+### 8.4 配列要素の扱い
+- `frames` は抽出時刻順に並べる。
+- `segments` は `start_timestamp_ms` 昇順に並べる。
+- 空データの場合も配列自体は出力する。
+
 ```json
 {
   "schema_version": "1.0.0",
@@ -392,12 +431,41 @@
       "background_color": "#FFCC00",
       "confidence": 0.94
     }
-  ]
+  ],
+  "run_metadata": {
+    "generated_at": "2026-04-28T07:00:00+09:00",
+    "application_version": "0.1.0",
+    "processing_time_ms": 18250
+  }
 }
 ```
 
+### 8.5 `run_metadata` 項目案
+- `generated_at`
+  - 型: `string`
+  - 形式: ISO 8601
+- `application_version`
+  - 型: `string`
+- `processing_time_ms`
+  - 型: `integer | null`
+- `warning_count`
+  - 型: `integer | null`
+- `error_count`
+  - 型: `integer | null`
+
+### 8.6 スキーマバージョン方針
+- 初期バージョンは `1.0.0` とする。
+- 後方互換を壊さない項目追加はマイナー更新とする。
+- 既存項目の意味変更や削除はメジャー更新とする。
+
 ## 9. CSV 出力スキーマ案
-### 9.1 セグメント出力
+### 9.1 基本方針
+- CSV は人間が表計算ソフトで確認しやすい派生出力とする。
+- 標準出力はセグメント単位 CSV とする。
+- 必要に応じてフレーム単位 CSV を別ファイルで出力する。
+- 1 ファイルに異なる粒度のデータを混在させない。
+
+### 9.2 セグメント出力
 標準の CSV 出力は、統合済みテロップ単位を 1 行とする。
 
 列案:
@@ -413,7 +481,10 @@
 - `background_color`
 - `confidence`
 
-### 9.2 フレーム単位出力
+列順方針:
+- 時系列確認しやすいよう、識別子、時刻、文字列、属性、信頼度の順に固定する。
+
+### 9.3 フレーム単位出力
 必要に応じて別 CSV として出力する。
 
 列案:
@@ -426,6 +497,22 @@
 - `stroke_color`
 - `background_color`
 - `confidence`
+
+### 9.4 CSV ファイル名案
+- セグメント単位: `segments.csv`
+- フレーム単位: `frames.csv`
+
+### 9.5 CSV 出力ルール
+- 文字コードは UTF-8 とする。
+- 1 行目はヘッダー行とする。
+- 不明値は空文字ではなく空欄出力とする。
+- 色は JSON と同じく `#RRGGBB` 形式で出力する。
+- 改行を含む OCR 結果は、CSV 上では改行をスペースに正規化してもよい。
+
+### 9.6 JSON と CSV の役割分担
+- JSON を完全データとして扱う。
+- CSV は確認・集計用の簡易出力とする。
+- JSON にある補助情報すべてを CSV に載せることは必須としない。
 
 ## 10. 今後の設計論点
 - WinUI 3 採用時のプロジェクト構成


### PR DESCRIPTION
## 概要
- JSON のトップレベル構造と必須項目を整理
- `run_metadata` と `schema_version` 方針を追加
- CSV の基本方針、列順、出力ルール、役割分担を追加

## 対応 Issue
- Closes #6

## 確認
- ドキュメント更新のみ
- ローカルで差分確認済み