### PR TITLE
[設計] データモデルとファイル配置を定義

### DIFF
--- a/docs/04_基本設計書.md
+++ b/docs/04_基本設計書.md
@@ -200,6 +200,34 @@ GUI 内の表示連動:
 
 ※ `work/` と `out/` は実行時生成物として `.gitignore` 対象とする。
 
+### 9.1 実行時ディレクトリ構成案
+`work/` 配下:
+- `work/runs/<run_id>/frames/`
+  - 抽出フレーム画像
+- `work/runs/<run_id>/ocr/`
+  - OCR ワーカー生結果
+- `work/runs/<run_id>/attributes/`
+  - 属性解析結果
+- `work/runs/<run_id>/logs/`
+  - 実行ログ
+
+`out/` 配下:
+- `out/<run_id>/segments.json`
+- `out/<run_id>/segments.csv`
+- `out/<run_id>/frames.csv`
+- `out/<run_id>/summary.log`
+
+### 9.2 配置方針
+- 実行ごとに `run_id` 単位でディレクトリを分ける。
+- 中間成果物と最終成果物を分離する。
+- JSON を正本、CSV を派生物として扱う。
+- ログは中間成果物側と最終成果物側の両方から追跡できるようにする。
+
+### 9.3 クリーンアップ方針
+- `work/runs/<run_id>/` は再実行や検証のため保持可能とする。
+- GUI から実行単位で削除できる構成を優先する。
+- `out/<run_id>/` は成果物として明示的削除以外では保持する。
+
 ## 10. 今後の詳細設計論点
 - GUI の View / ViewModel 分割方針
 - OCR ワーカーのプロセス形態

--- a/docs/05_詳細設計書.md
+++ b/docs/05_詳細設計書.md
@@ -199,13 +199,90 @@
 - フレーム単位ログ
 - ワーカー呼び出し単位ログ
 
-## 9. GUI 連携ポイント
+## 9. データモデル詳細
+### 9.1 内部モデル一覧
+- `VideoSource`
+- `ProcessingSettings`
+- `RunContext`
+- `FrameRecord`
+- `WorkerRequest`
+- `WorkerResponse`
+- `DetectionRecord`
+- `SegmentRecord`
+- `TimelineSegmentViewModel`
+- `ExportPackage`
+
+### 9.2 内部モデルと出力モデルの対応
+- `VideoSource`
+  - JSON: `source_video`
+- `ProcessingSettings`
+  - JSON: `processing_settings`
+- `FrameRecord`
+  - JSON: `frames[]`
+- `DetectionRecord`
+  - JSON: `frames[].detections[]`
+- `SegmentRecord`
+  - JSON: `segments[]`
+  - CSV: `segments.csv`
+- `TimelineSegmentViewModel`
+  - GUI 表示専用
+  - 永続化しない
+- `ExportPackage`
+  - JSON / CSV / ログ出力の統合単位
+
+### 9.3 `RunContext`
+役割:
+- 1 回の解析実行に対する共通状態を保持する。
+
+保持項目例:
+- `run_id`
+- `started_at`
+- `source_video`
+- `processing_settings`
+- `work_directory`
+- `output_directory`
+- `status`
+
+### 9.4 `ProcessingSettings`
+保持項目例:
+- `frame_interval_seconds`
+- `start_timestamp_ms`
+- `end_timestamp_ms`
+- `ocr_engine`
+- `offline_mode`
+- `overwrite_existing`
+
+## 10. ファイル配置詳細
+### 10.1 `run_id` 命名方針
+- 形式例: `20260428_073000_001`
+- 一意性を優先し、日時ベースを基本とする。
+
+### 10.2 中間成果物の保存方針
+- フレーム画像は `frames/` へ保存する。
+- OCR 生結果は `ocr/` へ保存する。
+- 属性解析中間結果は `attributes/` へ保存する。
+- 実行ログは `logs/` へ保存する。
+
+### 10.3 最終成果物の保存方針
+- JSON は `segments.json` を標準名とする。
+- CSV は `segments.csv` を標準名とし、必要に応じて `frames.csv` を出力する。
+- ログ要約は `summary.log` とする。
+
+### 10.4 クリーンアップ対象
+- フレーム画像
+- OCR 生結果
+- 属性解析中間結果
+- 実行ログ
+
+クリーンアップ非対象:
+- 最終成果物ディレクトリ
+
+## 11. GUI 連携ポイント
 - 処理開始時に進捗状態を `待機中` から `実行中` へ変更する。
 - フレーム抽出完了件数を進捗表示へ反映する。
 - OCR 失敗時は、対象フレームとエラー理由を GUI へ通知する。
 - セグメント確定後は、結果一覧とタイムライン表示モデルを同時更新する。
-
-## 10. 今後の詳細化項目
+## 12. 今後の詳細化項目
 - OCR ワーカー実体を別プロセスにするか同一プロセスにするか
 - バッチ実行時のキュー制御
 - タイムアウト値


### PR DESCRIPTION
## 概要
- 基本設計書に run_id 単位のディレクトリ構成案を追加
- 中間成果物と最終成果物の配置方針を追加
- 詳細設計書に内部モデル一覧と出力対応を追加
- クリーンアップ方針を追加

## 対応 Issue
- Closes #14

## 確認
- ドキュメント更新のみ
- ローカルで差分確認済み