### PR TITLE
[実装] 動画入力とフレーム抽出基盤を実装する

### DIFF
--- a/src/MovieTelopTranscriber.App/MainPage.xaml
+++ b/src/MovieTelopTranscriber.App/MainPage.xaml
@@ -59,7 +59,7 @@
                         PlaceholderText="Select a video file or enter a path"
                         Text="{x:Bind ViewModel.VideoPath, Mode=TwoWay}" />
                     <Button Grid.Column="1" Command="{x:Bind ViewModel.SelectVideoCommand}" Content="Browse" />
-                    <Button Grid.Column="2" Command="{x:Bind ViewModel.StartAnalysisCommand}" Content="Run" />
+                    <Button Grid.Column="2" Command="{x:Bind ViewModel.StartAnalysisCommand}" Content="Extract" />
                 </Grid>
             </Grid>
         </Border>
@@ -98,6 +98,10 @@
 
                     <StackPanel Grid.Row="1" Spacing="12">
                         <TextBlock Text="Settings" Style="{StaticResource SubtitleTextBlockStyle}" />
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Frame interval (sec)" />
+                            <TextBox Text="{x:Bind ViewModel.FrameIntervalText, Mode=TwoWay}" />
+                        </StackPanel>
                         <ItemsRepeater ItemsSource="{x:Bind ViewModel.SettingItems, Mode=OneWay}">
                             <ItemsRepeater.ItemTemplate>
                                 <DataTemplate x:DataType="models:SettingItem">
@@ -195,13 +199,13 @@
                                 <FontIcon Glyph="&#xE714;" FontSize="40" />
                                 <TextBlock Text="{x:Bind ViewModel.PreviewState, Mode=OneWay}" />
                                 <TextBlock
-                                    Text="Selected frame preview area"
+                                    Text="Frame extraction shell"
                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                             </StackPanel>
                         </Border>
 
                         <StackPanel Grid.Row="2" Spacing="6">
-                            <TextBlock Text="Selected telop" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                            <TextBlock Text="Selected item" Style="{StaticResource BodyStrongTextBlockStyle}" />
                             <TextBlock
                                 Text="{x:Bind ViewModel.SelectedSegmentSummary, Mode=OneWay}"
                                 TextWrapping="WrapWholeWords" />

--- a/src/MovieTelopTranscriber.App/Models/ExtractedFrameRecord.cs
+++ b/src/MovieTelopTranscriber.App/Models/ExtractedFrameRecord.cs
@@ -1,0 +1,3 @@
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record ExtractedFrameRecord(int FrameIndex, long TimestampMs, string ImagePath);

--- a/src/MovieTelopTranscriber.App/Models/FrameExtractionResult.cs
+++ b/src/MovieTelopTranscriber.App/Models/FrameExtractionResult.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record FrameExtractionResult(
+    string RunId,
+    string FramesDirectory,
+    IReadOnlyList<ExtractedFrameRecord> Frames);

--- a/src/MovieTelopTranscriber.App/Models/VideoMetadata.cs
+++ b/src/MovieTelopTranscriber.App/Models/VideoMetadata.cs
@@ -1,0 +1,10 @@
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record VideoMetadata(
+    string FilePath,
+    string FileName,
+    long DurationMs,
+    int Width,
+    int Height,
+    double Fps,
+    string Codec);

--- a/src/MovieTelopTranscriber.App/MovieTelopTranscriber.App.csproj
+++ b/src/MovieTelopTranscriber.App/MovieTelopTranscriber.App.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260416003" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="OpenCvSharp4.Windows" Version="4.13.0.20260302" />
   </ItemGroup>
 
   <!--

--- a/src/MovieTelopTranscriber.App/Services/OpenCvVideoProcessingService.cs
+++ b/src/MovieTelopTranscriber.App/Services/OpenCvVideoProcessingService.cs
@@ -1,0 +1,165 @@
+using MovieTelopTranscriber.App.Models;
+using OpenCvSharp;
+
+namespace MovieTelopTranscriber.App.Services;
+
+public sealed class OpenCvVideoProcessingService
+{
+    public Task<VideoMetadata> ReadMetadataAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var capture = new VideoCapture(filePath);
+            if (!capture.IsOpened())
+            {
+                throw new InvalidOperationException($"Failed to open video file: {filePath}");
+            }
+
+            var width = Convert.ToInt32(capture.FrameWidth);
+            var height = Convert.ToInt32(capture.FrameHeight);
+            var fps = capture.Fps;
+            var frameCount = capture.FrameCount;
+            var durationMs = fps > 0 ? (long)Math.Round((frameCount / fps) * 1000d) : 0L;
+            var codec = DecodeFourCc(Convert.ToInt32(capture.Get(VideoCaptureProperties.FourCC)));
+
+            return new VideoMetadata(
+                filePath,
+                Path.GetFileName(filePath),
+                durationMs,
+                width,
+                height,
+                fps,
+                codec);
+        }, cancellationToken);
+    }
+
+    public Task<FrameExtractionResult> ExtractFramesAsync(
+        VideoMetadata metadata,
+        double intervalSeconds,
+        IProgress<double>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            if (intervalSeconds <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(intervalSeconds), "Interval must be greater than zero.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var capture = new VideoCapture(metadata.FilePath);
+            if (!capture.IsOpened())
+            {
+                throw new InvalidOperationException($"Failed to open video file: {metadata.FilePath}");
+            }
+
+            var runId = CreateRunId();
+            var framesDirectory = CreateFramesDirectory(runId);
+
+            var durationMs = metadata.DurationMs > 0 ? metadata.DurationMs : EstimateDurationMs(capture);
+            var timestamps = BuildCaptureTimestamps(durationMs, intervalSeconds);
+            var frames = new List<ExtractedFrameRecord>(timestamps.Count);
+
+            for (var i = 0; i < timestamps.Count; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var timestampMs = timestamps[i];
+                capture.Set(VideoCaptureProperties.PosMsec, timestampMs);
+
+                using var frame = new Mat();
+                if (!capture.Read(frame) || frame.Empty())
+                {
+                    continue;
+                }
+
+                var frameIndex = Convert.ToInt32(capture.Get(VideoCaptureProperties.PosFrames));
+                var imagePath = Path.Combine(framesDirectory, $"frame_{frameIndex:D6}_{timestampMs:D8}ms.png");
+                Cv2.ImWrite(imagePath, frame);
+
+                frames.Add(new ExtractedFrameRecord(frameIndex, timestampMs, imagePath));
+                progress?.Report(((double)(i + 1) / timestamps.Count) * 100d);
+            }
+
+            return new FrameExtractionResult(runId, framesDirectory, frames);
+        }, cancellationToken);
+    }
+
+    private static long EstimateDurationMs(VideoCapture capture)
+    {
+        var fps = capture.Fps;
+        var frameCount = capture.FrameCount;
+        return fps > 0 ? (long)Math.Round((frameCount / fps) * 1000d) : 0L;
+    }
+
+    private static List<long> BuildCaptureTimestamps(long durationMs, double intervalSeconds)
+    {
+        var intervalMs = (long)Math.Round(intervalSeconds * 1000d);
+        var timestamps = new List<long>();
+
+        if (durationMs <= 0)
+        {
+            timestamps.Add(0);
+            return timestamps;
+        }
+
+        for (long timestampMs = 0; timestampMs <= durationMs; timestampMs += intervalMs)
+        {
+            timestamps.Add(timestampMs);
+        }
+
+        if (timestamps.Count == 0 || timestamps[^1] != durationMs)
+        {
+            timestamps.Add(durationMs);
+        }
+
+        return timestamps;
+    }
+
+    private static string CreateFramesDirectory(string runId)
+    {
+        var projectRoot = ResolveProjectRoot();
+        var framesDirectory = Path.Combine(projectRoot, "work", "runs", runId, "frames");
+        Directory.CreateDirectory(framesDirectory);
+        return framesDirectory;
+    }
+
+    private static string ResolveProjectRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (current is not null)
+        {
+            var docs = Path.Combine(current.FullName, "docs");
+            var src = Path.Combine(current.FullName, "src");
+            if (Directory.Exists(docs) && Directory.Exists(src))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        return Directory.GetCurrentDirectory();
+    }
+
+    private static string CreateRunId()
+    {
+        return $"{DateTime.Now:yyyyMMdd_HHmmss}_{Guid.NewGuid():N}"[..20];
+    }
+
+    private static string DecodeFourCc(int fourCc)
+    {
+        Span<char> chars = stackalloc char[4];
+        chars[0] = (char)(fourCc & 0xFF);
+        chars[1] = (char)((fourCc >> 8) & 0xFF);
+        chars[2] = (char)((fourCc >> 16) & 0xFF);
+        chars[3] = (char)((fourCc >> 24) & 0xFF);
+
+        var value = new string(chars).TrimEnd('\0');
+        return string.IsNullOrWhiteSpace(value) ? "unknown" : value;
+    }
+}

--- a/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
+++ b/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
@@ -2,42 +2,24 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using MovieTelopTranscriber.App.Models;
+using MovieTelopTranscriber.App.Services;
+using Windows.Storage.Pickers;
 
 namespace MovieTelopTranscriber.App.ViewModels;
 
 public partial class MainPageViewModel : ObservableObject
 {
+    private readonly OpenCvVideoProcessingService _videoProcessingService = new();
+
     public MainPageViewModel()
     {
-        SettingItems = new ObservableCollection<SettingItem>
-        {
-            new("Frame interval", "1.0 sec", "Default capture interval. This will become user-configurable in a later task."),
-            new("OCR engine", "PaddleOCR", "Initial placeholder based on the offline worker design."),
-            new("Export format", "JSON / CSV", "Segment-level and frame-level outputs are planned.")
-        };
+        SettingItems = new ObservableCollection<SettingItem>();
+        InfoCards = new ObservableCollection<InfoCardItem>();
+        TimelineSegments = new ObservableCollection<TimelineSegment>();
+        ResultRows = new ObservableCollection<ResultRow>();
 
-        InfoCards = new ObservableCollection<InfoCardItem>
-        {
-            new("Video", "Not selected", "The app targets common formats with MP4 as the primary input."),
-            new("Pipeline", "Idle", "Frame extraction and OCR will be connected in the next implementation tasks."),
-            new("Sample rows", "3", "Temporary records for shell verification.")
-        };
-
-        TimelineSegments = new ObservableCollection<TimelineSegment>
-        {
-            new("00:00.0 - 00:02.0", "Opening title", "white / black outline / no plate"),
-            new("00:05.0 - 00:07.0", "Interview subtitle", "yellow / black outline / no plate"),
-            new("00:12.0 - 00:15.0", "Program notice", "white / blue plate")
-        };
-
-        ResultRows = new ObservableCollection<ResultRow>
-        {
-            new("00:00.0 - 00:02.0", "Title", "Opening title", "font=Yu Gothic UI, text=#FFFFFF, outline=#000000"),
-            new("00:05.0 - 00:07.0", "Subtitle", "Today special feature starts here", "font=Meiryo UI, text=#F2D64B, outline=#000000"),
-            new("00:12.0 - 00:15.0", "Notice", "Every Tuesday 21:00", "font=Yu Gothic UI Semibold, text=#FFFFFF, background=#1E3A8A")
-        };
-
-        SelectedTimelineSegment = TimelineSegments[0];
+        RefreshStaticCollections();
+        ResetDynamicCollections();
     }
 
     public ObservableCollection<SettingItem> SettingItems { get; }
@@ -49,10 +31,10 @@ public partial class MainPageViewModel : ObservableObject
     public ObservableCollection<ResultRow> ResultRows { get; }
 
     [ObservableProperty]
-    public partial string WindowDescription { get; set; } = "WinUI 3 desktop shell for video input, OCR flow, and timeline-linked telop review.";
+    public partial string WindowDescription { get; set; } = "WinUI 3 desktop shell for video input, frame extraction, and timeline-linked review.";
 
     [ObservableProperty]
-    public partial string VideoPath { get; set; } = @"D:\Samples\input.mp4";
+    public partial string VideoPath { get; set; } = string.Empty;
 
     [ObservableProperty]
     public partial string SupportedFormats { get; set; } = ".mp4, .mov, .avi, .mkv, .wmv";
@@ -61,16 +43,39 @@ public partial class MainPageViewModel : ObservableObject
     public partial string PreviewState { get; set; } = "Video not loaded";
 
     [ObservableProperty]
-    public partial string ActivityMessage { get; set; } = "Application shell initialized. Video loading, frame extraction, and OCR worker wiring are scheduled in the next tasks.";
+    public partial string ActivityMessage { get; set; } = "Select a video file to load metadata and extract frames.";
 
     [ObservableProperty]
-    public partial string StatusMessage { get; set; } = "App foundation is ready. The three-pane layout and timeline binding shell can now be reviewed.";
+    public partial string StatusMessage { get; set; } = "App foundation is ready. Video input and frame extraction are available on this screen.";
 
     [ObservableProperty]
-    public partial double ProgressValue { get; set; } = 18;
+    public partial double ProgressValue { get; set; }
 
     [ObservableProperty]
     public partial bool ShowTimelineSelection { get; set; } = true;
+
+    [ObservableProperty]
+    public partial bool IsBusy { get; set; }
+
+    public bool CanInteract => !IsBusy;
+
+    [ObservableProperty]
+    public partial string FrameIntervalText { get; set; } = "1.0";
+
+    [ObservableProperty]
+    public partial string DurationText { get; set; } = "-";
+
+    [ObservableProperty]
+    public partial string ResolutionText { get; set; } = "-";
+
+    [ObservableProperty]
+    public partial string FpsText { get; set; } = "-";
+
+    [ObservableProperty]
+    public partial string CodecText { get; set; } = "-";
+
+    [ObservableProperty]
+    public partial string WorkDirectoryText { get; set; } = "-";
 
     [ObservableProperty]
     public partial TimelineSegment? SelectedTimelineSegment { get; set; }
@@ -85,19 +90,96 @@ public partial class MainPageViewModel : ObservableObject
         OnPropertyChanged(nameof(SelectedSegmentSummary));
     }
 
-    [RelayCommand]
-    private void SelectVideo()
+    partial void OnIsBusyChanged(bool value)
     {
-        StatusMessage = "Video picker is not wired yet. This command is currently a shell placeholder.";
+        OnPropertyChanged(nameof(CanInteract));
+    }
+
+    partial void OnFrameIntervalTextChanged(string value)
+    {
+        RefreshStaticCollections();
     }
 
     [RelayCommand]
-    private void StartAnalysis()
+    private async Task SelectVideoAsync()
     {
-        PreviewState = "Preparing analysis";
-        ActivityMessage = "Analysis pipeline is not connected yet. The shell only updates the visible state for now.";
-        ProgressValue = 24;
-        StatusMessage = "Run command accepted. Frame extraction and OCR worker integration will land in follow-up issues.";
+        if (IsBusy)
+        {
+            return;
+        }
+
+        var picker = new FileOpenPicker();
+        picker.SuggestedStartLocation = PickerLocationId.VideosLibrary;
+        foreach (var extension in SupportedFormats.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        {
+            picker.FileTypeFilter.Add(extension);
+        }
+
+        WinRT.Interop.InitializeWithWindow.Initialize(picker, App.WindowHandle);
+        var file = await picker.PickSingleFileAsync();
+        if (file is null)
+        {
+            return;
+        }
+
+        await LoadVideoAsync(file.Path);
+    }
+
+    [RelayCommand]
+    private async Task StartAnalysisAsync()
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(VideoPath) || !File.Exists(VideoPath))
+        {
+            StatusMessage = "Select a valid video file before running extraction.";
+            return;
+        }
+
+        IsBusy = true;
+        ProgressValue = 0;
+        PreviewState = "Extracting frames";
+        StatusMessage = "Frame extraction started.";
+        ActivityMessage = "Frames are being written to the work directory.";
+
+        try
+        {
+            var metadata = await _videoProcessingService.ReadMetadataAsync(VideoPath);
+            var progress = new Progress<double>(value => ProgressValue = value);
+            var intervalSeconds = ParseFrameIntervalSeconds();
+            var result = await _videoProcessingService.ExtractFramesAsync(metadata, intervalSeconds, progress);
+
+            WorkDirectoryText = result.FramesDirectory;
+            TimelineSegments.Clear();
+            ResultRows.Clear();
+
+            foreach (var frame in result.Frames)
+            {
+                var timeLabel = FormatTimestamp(frame.TimestampMs);
+                TimelineSegments.Add(new TimelineSegment(timeLabel, $"Frame {frame.FrameIndex:D6}", Path.GetFileName(frame.ImagePath)));
+                ResultRows.Add(new ResultRow(timeLabel, "Frame", Path.GetFileName(frame.ImagePath), frame.ImagePath));
+            }
+
+            SelectedTimelineSegment = TimelineSegments.FirstOrDefault();
+            PreviewState = result.Frames.Count > 0 ? $"Extracted {result.Frames.Count} frames" : "No frames extracted";
+            ActivityMessage = $"Saved {result.Frames.Count} frames to {result.FramesDirectory}.";
+            StatusMessage = $"Frame extraction completed. Run ID: {result.RunId}";
+
+            RefreshInfoCards(metadata, result.Frames.Count);
+        }
+        catch (Exception ex)
+        {
+            PreviewState = "Extraction failed";
+            ActivityMessage = ex.Message;
+            StatusMessage = "Frame extraction failed.";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
     }
 
     [RelayCommand]
@@ -110,5 +192,83 @@ public partial class MainPageViewModel : ObservableObject
     private void OpenExport()
     {
         StatusMessage = "Export window will be implemented later as a non-modal child window.";
+    }
+
+    private async Task LoadVideoAsync(string path)
+    {
+        IsBusy = true;
+        ProgressValue = 0;
+        PreviewState = "Loading metadata";
+        ActivityMessage = "Reading video metadata.";
+
+        try
+        {
+            VideoPath = path;
+            var metadata = await _videoProcessingService.ReadMetadataAsync(path);
+            DurationText = FormatTimestamp(metadata.DurationMs);
+            ResolutionText = $"{metadata.Width} x {metadata.Height}";
+            FpsText = $"{metadata.Fps:F3}";
+            CodecText = metadata.Codec;
+            WorkDirectoryText = "-";
+            PreviewState = "Ready";
+            StatusMessage = $"Loaded {metadata.FileName}";
+            ActivityMessage = "Metadata loaded. You can now run frame extraction.";
+
+            RefreshInfoCards(metadata, 0);
+            TimelineSegments.Clear();
+            ResultRows.Clear();
+            TimelineSegments.Add(new TimelineSegment("preview", metadata.FileName, "metadata loaded"));
+            ResultRows.Add(new ResultRow("metadata", "Video", metadata.FileName, $"{ResolutionText} / {FpsText} fps / {CodecText}"));
+            SelectedTimelineSegment = TimelineSegments[0];
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = "Failed to load video metadata.";
+            ActivityMessage = ex.Message;
+            PreviewState = "Load failed";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private void RefreshStaticCollections()
+    {
+        SettingItems.Clear();
+        SettingItems.Add(new SettingItem("Frame interval", $"{ParseFrameIntervalSeconds():F1} sec", "Default extraction interval."));
+        SettingItems.Add(new SettingItem("OCR engine", "PaddleOCR", "Reserved for the next implementation task."));
+        SettingItems.Add(new SettingItem("Output", "work/runs/<run_id>/frames", "Frames are saved under the per-run work directory."));
+    }
+
+    private void ResetDynamicCollections()
+    {
+        RefreshInfoCards(null, 0);
+        TimelineSegments.Clear();
+        ResultRows.Clear();
+        TimelineSegments.Add(new TimelineSegment("timeline", "No frames yet", "load a video to begin"));
+        ResultRows.Add(new ResultRow("result", "Status", "No extracted frames", "Run frame extraction to populate this list."));
+        SelectedTimelineSegment = TimelineSegments[0];
+    }
+
+    private void RefreshInfoCards(VideoMetadata? metadata, int frameCount)
+    {
+        InfoCards.Clear();
+        InfoCards.Add(new InfoCardItem("Video", metadata?.FileName ?? "Not selected", "Current source video"));
+        InfoCards.Add(new InfoCardItem("Frames", frameCount.ToString(), "Extracted frame count"));
+        InfoCards.Add(new InfoCardItem("Work", WorkDirectoryText, "Current output directory"));
+    }
+
+    private static string FormatTimestamp(long timestampMs)
+    {
+        var ts = TimeSpan.FromMilliseconds(timestampMs);
+        return $"{(int)ts.TotalHours:00}:{ts.Minutes:00}:{ts.Seconds:00}.{ts.Milliseconds:000}";
+    }
+
+    private double ParseFrameIntervalSeconds()
+    {
+        return double.TryParse(FrameIntervalText, out var seconds) && seconds > 0
+            ? seconds
+            : 1.0d;
     }
 }


### PR DESCRIPTION
## 概要
- 動画ファイル選択とメタデータ取得を実装
- フレーム抽出設定入力と `work/runs/<run_id>/frames` への保存を実装
- OpenCvSharp ベースのローカル動画処理サービスを追加
- タイムラインと結果一覧へ抽出結果を反映

## 確認
- `dotnet build src/MovieTelopTranscriber.sln`
- `dotnet run --project work/VerifyVideoProcessing/VerifyVideoProcessing.csproj`
- `src/MovieTelopTranscriber.App/bin/x64/Debug/net10.0-windows10.0.26100.0/MovieTelopTranscriber.App.exe` 起動確認

Closes #30