### PR TITLE
タイムライン・一覧・出力機能を実装する

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@
 - 外部 OCR ワーカーは `MOVIE_TELOP_OCR_WORKER` 環境変数で指定する。
 - 未指定時はフレーム同名の `.ocr.json` サイドカーを読み込み、サイドカーがない場合は空検出として処理を継続する。
 - 中間成果物は `work/runs/<run_id>/frames`、`ocr`、`attributes` に分けて保存する。
+- 最終成果物は `work/runs/<run_id>/output/segments.json`、`segments.csv`、`frames.csv` として保存する。

--- a/docs/07_実装メモ.md
+++ b/docs/07_実装メモ.md
@@ -22,7 +22,16 @@
 - OCR リクエストとレスポンス: `work/runs/<run_id>/ocr/`
 - 属性解析結果: `work/runs/<run_id>/attributes/`
 
-## 5. 後続工程で再評価する項目
+## 5. セグメント統合と出力
+- `TelopSegmentMerger` が、同一文字列・同一属性キーの連続フレームを 1 セグメントへ統合する。
+- セグメントの終了時刻は、最後に検出されたフレーム時刻にフレーム抽出間隔を加算して算出する。
+- `ExportPackageWriter` が `work/runs/<run_id>/output/` に以下を保存する。
+- `segments.json`: 完全出力。
+- `segments.csv`: セグメント単位 CSV。
+- `frames.csv`: フレーム単位 CSV。
+- OCR 検出が 0 件の場合も、空配列を含む JSON とヘッダー付き CSV を生成する。
+
+## 6. 後続工程で再評価する項目
 - PaddleOCR / Tesseract / Windows 標準 OCR の採用実体。
 - OCR モデルや外部ランタイムを配布物へ同梱する範囲。
 - 色属性推定の画像解析方式。

--- a/docs/design/04_処理パイプライン詳細設計.md
+++ b/docs/design/04_処理パイプライン詳細設計.md
@@ -14,6 +14,8 @@ OCR ワーカー連携、処理順序、I/O 契約、エラー返却、再実行
 8. JSON / CSV 出力
 9. GUI 表示更新
 
+初期実装では、OCR / 属性解析後に `TelopSegmentMerger` が同一文字列・同一属性キーの連続フレームをセグメントへ統合し、`ExportPackageWriter` がランディレクトリ配下の `output/` へ JSON / CSV を保存する。
+
 ## 3. OCR ワーカー連携方針
 ### 3.1 基本方針
 - GUI 本体は OCR エンジンの詳細実装を直接呼び出さない。
@@ -201,6 +203,12 @@ OCR ワーカー連携、処理順序、I/O 契約、エラー返却、再実行
 - OCR リクエストとレスポンス: `work/runs/<run_id>/ocr/`
 - 属性解析結果: `work/runs/<run_id>/attributes/`
 - 外部ワーカー未設定時も、同じ配置規約でリクエストとレスポンスを保存する。
+
+### 7.4 初期実装の最終成果物
+- JSON 出力: `work/runs/<run_id>/output/segments.json`
+- セグメント CSV: `work/runs/<run_id>/output/segments.csv`
+- フレーム CSV: `work/runs/<run_id>/output/frames.csv`
+- 出力ファイルは OCR 検出がない場合も生成する。
 
 ### 7.2 ログ粒度
 - 実行単位ログ

--- a/docs/design/05_データモデル詳細設計.md
+++ b/docs/design/05_データモデル詳細設計.md
@@ -22,6 +22,12 @@
 - `TelopAttributeRecord`: OCR 検出結果へ付与した属性解析結果を保持する。
 - `AttributeAnalysisResult`: フレーム単位の属性解析結果を保持する。
 - `FrameAnalysisResult`: 抽出フレーム、OCR 結果、属性解析結果を結び付ける。
+- `SegmentRecord`: 統合済みテロップ単位の時刻、文字列、属性、信頼度、元フレーム数を保持する。
+- `ExportPackage`: JSON 出力全体のトップレベル構造を保持する。
+- `FrameExportRecord`: フレーム単位出力の 1 行相当を保持する。
+- `ProcessingSettingsRecord`: 出力に残す実行設定を保持する。
+- `RunMetadataRecord`: 出力生成時刻、アプリバージョン、処理時間、警告/エラー件数を保持する。
+- `ExportWriteResult`: 生成した JSON / CSV ファイルパスを保持する。
 - `ProcessingError`: 失敗コード、表示メッセージ、詳細、再実行可否を保持する。
 
 ## 2. 内部モデルと出力モデルの対応
@@ -81,6 +87,8 @@
 - JSON は `segments.json` を標準名とする。
 - CSV は `segments.csv` を標準名とし、必要に応じて `frames.csv` を出力する。
 - ログ要約は `summary.log` とする。
+
+初期実装では、最終成果物を `work/runs/<run_id>/output/` に保存する。
 
 ### 5.4 クリーンアップ対象
 - フレーム画像

--- a/docs/spec/04_出力仕様.md
+++ b/docs/spec/04_出力仕様.md
@@ -39,6 +39,7 @@
 - `frames` は抽出時刻順に並べる。
 - `segments` は `start_timestamp_ms` 昇順に並べる。
 - 空データの場合も配列自体は出力する。
+- 初期実装では `work/runs/<run_id>/output/segments.json` として保存する。
 
 ```json
 {
@@ -159,6 +160,8 @@
 - セグメント単位: `segments.csv`
 - フレーム単位: `frames.csv`
 
+初期実装では、どちらも `work/runs/<run_id>/output/` に保存する。
+
 ### 2.5 CSV 出力ルール
 - 文字コードは UTF-8 とする。
 - 1 行目はヘッダー行とする。
@@ -170,3 +173,10 @@
 - JSON を完全データとして扱う。
 - CSV は確認・集計用の簡易出力とする。
 - JSON にある補助情報すべてを CSV に載せることは必須としない。
+
+## 3. 初期実装の出力範囲
+- `segments.json`: 入力動画、処理設定、フレーム単位検出、セグメント単位結果、実行メタデータを含む。
+- `segments.csv`: セグメント単位の確認用 CSV。
+- `frames.csv`: フレーム単位の確認用 CSV。
+- OCR 検出が 0 件の場合も、JSON と CSV は生成する。
+- GUI の Export ボタンは、非モーダル出力画面実装前の暫定動作として最新 `segments.json` のパスをステータス表示する。

--- a/src/MovieTelopTranscriber.App/Models/ExportPackage.cs
+++ b/src/MovieTelopTranscriber.App/Models/ExportPackage.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record ExportPackage(
+    string SchemaVersion,
+    VideoMetadata SourceVideo,
+    ProcessingSettingsRecord ProcessingSettings,
+    IReadOnlyList<FrameExportRecord> Frames,
+    IReadOnlyList<SegmentRecord> Segments,
+    RunMetadataRecord RunMetadata);

--- a/src/MovieTelopTranscriber.App/Models/ExportWriteResult.cs
+++ b/src/MovieTelopTranscriber.App/Models/ExportWriteResult.cs
@@ -1,0 +1,7 @@
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record ExportWriteResult(
+    string OutputDirectory,
+    string JsonPath,
+    string SegmentsCsvPath,
+    string FramesCsvPath);

--- a/src/MovieTelopTranscriber.App/Models/FrameExportRecord.cs
+++ b/src/MovieTelopTranscriber.App/Models/FrameExportRecord.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record FrameExportRecord(
+    int FrameIndex,
+    long TimestampMs,
+    string ImagePath,
+    IReadOnlyList<TelopAttributeRecord> Detections);

--- a/src/MovieTelopTranscriber.App/Models/ProcessingSettingsRecord.cs
+++ b/src/MovieTelopTranscriber.App/Models/ProcessingSettingsRecord.cs
@@ -1,0 +1,6 @@
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record ProcessingSettingsRecord(
+    double FrameIntervalSeconds,
+    string OcrEngine,
+    bool OfflineMode);

--- a/src/MovieTelopTranscriber.App/Models/RunMetadataRecord.cs
+++ b/src/MovieTelopTranscriber.App/Models/RunMetadataRecord.cs
@@ -1,0 +1,8 @@
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record RunMetadataRecord(
+    DateTimeOffset GeneratedAt,
+    string ApplicationVersion,
+    long? ProcessingTimeMs,
+    int WarningCount,
+    int ErrorCount);

--- a/src/MovieTelopTranscriber.App/Models/SegmentRecord.cs
+++ b/src/MovieTelopTranscriber.App/Models/SegmentRecord.cs
@@ -1,0 +1,16 @@
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record SegmentRecord(
+    string SegmentId,
+    long StartTimestampMs,
+    long EndTimestampMs,
+    string Text,
+    string TextType,
+    string? FontFamily,
+    double? FontSize,
+    string? FontSizeUnit,
+    string? TextColor,
+    string? StrokeColor,
+    string? BackgroundColor,
+    double? Confidence,
+    int SourceFrameCount);

--- a/src/MovieTelopTranscriber.App/Services/ExportPackageWriter.cs
+++ b/src/MovieTelopTranscriber.App/Services/ExportPackageWriter.cs
@@ -1,0 +1,151 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using MovieTelopTranscriber.App.Models;
+
+namespace MovieTelopTranscriber.App.Services;
+
+public sealed class ExportPackageWriter
+{
+    public async Task<ExportWriteResult> WriteAsync(
+        VideoMetadata sourceVideo,
+        FrameExtractionResult frameExtractionResult,
+        IReadOnlyList<FrameAnalysisResult> frameAnalyses,
+        IReadOnlyList<SegmentRecord> segments,
+        double frameIntervalSeconds,
+        string ocrEngine,
+        long? processingTimeMs,
+        int warningCount,
+        int errorCount,
+        CancellationToken cancellationToken = default)
+    {
+        var outputDirectory = Path.Combine(frameExtractionResult.RunDirectory, "output");
+        Directory.CreateDirectory(outputDirectory);
+
+        var package = new ExportPackage(
+            "1.0.0",
+            sourceVideo,
+            new ProcessingSettingsRecord(frameIntervalSeconds, ocrEngine, true),
+            frameAnalyses
+                .Select(frame => new FrameExportRecord(
+                    frame.Frame.FrameIndex,
+                    frame.Frame.TimestampMs,
+                    frame.Frame.ImagePath,
+                    frame.Attributes.Detections))
+                .ToArray(),
+            segments,
+            new RunMetadataRecord(
+                DateTimeOffset.Now,
+                GetApplicationVersion(),
+                processingTimeMs,
+                warningCount,
+                errorCount));
+
+        var jsonPath = Path.Combine(outputDirectory, "segments.json");
+        await using (var stream = File.Create(jsonPath))
+        {
+            await JsonSerializer.SerializeAsync(stream, package, OcrContractJson.Options, cancellationToken);
+        }
+
+        var segmentsCsvPath = Path.Combine(outputDirectory, "segments.csv");
+        await File.WriteAllTextAsync(segmentsCsvPath, BuildSegmentsCsv(segments), new UTF8Encoding(false), cancellationToken);
+
+        var framesCsvPath = Path.Combine(outputDirectory, "frames.csv");
+        await File.WriteAllTextAsync(framesCsvPath, BuildFramesCsv(package.Frames), new UTF8Encoding(false), cancellationToken);
+
+        return new ExportWriteResult(outputDirectory, jsonPath, segmentsCsvPath, framesCsvPath);
+    }
+
+    private static string BuildSegmentsCsv(IReadOnlyList<SegmentRecord> segments)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("segment_id,start_timestamp_ms,end_timestamp_ms,text,text_type,font_family,font_size,text_color,stroke_color,background_color,confidence");
+
+        foreach (var segment in segments)
+        {
+            builder.AppendLine(string.Join(
+                ',',
+                Csv(segment.SegmentId),
+                segment.StartTimestampMs.ToString(CultureInfo.InvariantCulture),
+                segment.EndTimestampMs.ToString(CultureInfo.InvariantCulture),
+                Csv(segment.Text),
+                Csv(segment.TextType),
+                Csv(segment.FontFamily),
+                Csv(FormatNullable(segment.FontSize)),
+                Csv(segment.TextColor),
+                Csv(segment.StrokeColor),
+                Csv(segment.BackgroundColor),
+                Csv(FormatNullable(segment.Confidence))));
+        }
+
+        return builder.ToString();
+    }
+
+    private static string BuildFramesCsv(IReadOnlyList<FrameExportRecord> frames)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("frame_index,timestamp_ms,text,font_family,font_size,text_color,stroke_color,background_color,confidence");
+
+        foreach (var frame in frames)
+        {
+            if (frame.Detections.Count == 0)
+            {
+                builder.AppendLine(string.Join(
+                    ',',
+                    frame.FrameIndex.ToString(CultureInfo.InvariantCulture),
+                    frame.TimestampMs.ToString(CultureInfo.InvariantCulture),
+                    string.Empty,
+                    string.Empty,
+                    string.Empty,
+                    string.Empty,
+                    string.Empty,
+                    string.Empty,
+                    string.Empty));
+                continue;
+            }
+
+            foreach (var detection in frame.Detections)
+            {
+                builder.AppendLine(string.Join(
+                    ',',
+                    frame.FrameIndex.ToString(CultureInfo.InvariantCulture),
+                    frame.TimestampMs.ToString(CultureInfo.InvariantCulture),
+                    Csv(detection.Text),
+                    Csv(detection.FontFamily),
+                    Csv(FormatNullable(detection.FontSize)),
+                    Csv(detection.TextColor),
+                    Csv(detection.StrokeColor),
+                    Csv(detection.BackgroundColor),
+                    Csv(FormatNullable(detection.Confidence))));
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static string Csv(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var normalized = value.Replace("\r", " ", StringComparison.Ordinal).Replace("\n", " ", StringComparison.Ordinal);
+        return normalized.Contains('"', StringComparison.Ordinal)
+            || normalized.Contains(',', StringComparison.Ordinal)
+            || normalized.Contains(' ', StringComparison.Ordinal)
+            ? $"\"{normalized.Replace("\"", "\"\"", StringComparison.Ordinal)}\""
+            : normalized;
+    }
+
+    private static string? FormatNullable(double? value)
+    {
+        return value?.ToString("0.####", CultureInfo.InvariantCulture);
+    }
+
+    private static string GetApplicationVersion()
+    {
+        return Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0";
+    }
+}

--- a/src/MovieTelopTranscriber.App/Services/TelopSegmentMerger.cs
+++ b/src/MovieTelopTranscriber.App/Services/TelopSegmentMerger.cs
@@ -1,0 +1,140 @@
+using MovieTelopTranscriber.App.Models;
+
+namespace MovieTelopTranscriber.App.Services;
+
+public sealed class TelopSegmentMerger
+{
+    public IReadOnlyList<SegmentRecord> Merge(
+        IReadOnlyList<FrameAnalysisResult> frameAnalyses,
+        double frameIntervalSeconds)
+    {
+        var defaultDurationMs = Math.Max(1L, (long)Math.Round(frameIntervalSeconds * 1000d));
+        var maxGapMs = Math.Max(defaultDurationMs, (long)Math.Round(defaultDurationMs * 1.5d));
+        var completed = new List<SegmentBuilder>();
+        var activeByKey = new Dictionary<string, SegmentBuilder>();
+
+        foreach (var analysis in frameAnalyses.OrderBy(frame => frame.Frame.TimestampMs))
+        {
+            foreach (var detection in analysis.Attributes.Detections)
+            {
+                var key = CreateMergeKey(detection);
+                if (activeByKey.TryGetValue(key, out var active)
+                    && analysis.Frame.TimestampMs - active.LastTimestampMs <= maxGapMs)
+                {
+                    active.Extend(analysis.Frame.TimestampMs, defaultDurationMs, detection);
+                    continue;
+                }
+
+                if (activeByKey.Remove(key, out var stale))
+                {
+                    completed.Add(stale);
+                }
+
+                activeByKey[key] = new SegmentBuilder(
+                    analysis.Frame.TimestampMs,
+                    defaultDurationMs,
+                    detection);
+            }
+        }
+
+        completed.AddRange(activeByKey.Values);
+
+        return completed
+            .OrderBy(segment => segment.StartTimestampMs)
+            .Select((segment, index) => segment.ToSegmentRecord($"seg-{index + 1:D4}"))
+            .ToArray();
+    }
+
+    private static string CreateMergeKey(TelopAttributeRecord detection)
+    {
+        return string.Join(
+            "|",
+            detection.Text,
+            detection.TextType,
+            detection.FontFamily ?? string.Empty,
+            detection.TextColor ?? string.Empty,
+            detection.StrokeColor ?? string.Empty,
+            detection.BackgroundColor ?? string.Empty);
+    }
+
+    private sealed class SegmentBuilder
+    {
+        private readonly List<double> _confidences = new();
+
+        public SegmentBuilder(long timestampMs, long defaultDurationMs, TelopAttributeRecord detection)
+        {
+            StartTimestampMs = timestampMs;
+            EndTimestampMs = timestampMs + defaultDurationMs;
+            LastTimestampMs = timestampMs;
+            Text = detection.Text;
+            TextType = detection.TextType;
+            FontFamily = detection.FontFamily;
+            FontSize = detection.FontSize;
+            FontSizeUnit = detection.FontSizeUnit;
+            TextColor = detection.TextColor;
+            StrokeColor = detection.StrokeColor;
+            BackgroundColor = detection.BackgroundColor;
+            AddConfidence(detection.Confidence);
+            SourceFrameCount = 1;
+        }
+
+        public long StartTimestampMs { get; }
+
+        public long EndTimestampMs { get; private set; }
+
+        public long LastTimestampMs { get; private set; }
+
+        private string Text { get; }
+
+        private string TextType { get; }
+
+        private string? FontFamily { get; }
+
+        private double? FontSize { get; }
+
+        private string? FontSizeUnit { get; }
+
+        private string? TextColor { get; }
+
+        private string? StrokeColor { get; }
+
+        private string? BackgroundColor { get; }
+
+        private int SourceFrameCount { get; set; }
+
+        public void Extend(long timestampMs, long defaultDurationMs, TelopAttributeRecord detection)
+        {
+            LastTimestampMs = timestampMs;
+            EndTimestampMs = timestampMs + defaultDurationMs;
+            SourceFrameCount++;
+            AddConfidence(detection.Confidence);
+        }
+
+        public SegmentRecord ToSegmentRecord(string segmentId)
+        {
+            var confidence = _confidences.Count == 0 ? (double?)null : Math.Round(_confidences.Average(), 4);
+            return new SegmentRecord(
+                segmentId,
+                StartTimestampMs,
+                EndTimestampMs,
+                Text,
+                TextType,
+                FontFamily,
+                FontSize,
+                FontSizeUnit,
+                TextColor,
+                StrokeColor,
+                BackgroundColor,
+                confidence,
+                SourceFrameCount);
+        }
+
+        private void AddConfidence(double? confidence)
+        {
+            if (confidence is not null)
+            {
+                _confidences.Add(confidence.Value);
+            }
+        }
+    }
+}

--- a/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
+++ b/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using MovieTelopTranscriber.App.Models;
@@ -11,7 +12,11 @@ public partial class MainPageViewModel : ObservableObject
 {
     private readonly OpenCvVideoProcessingService _videoProcessingService = new();
     private readonly TelopFrameAnalysisService _frameAnalysisService = new();
+    private readonly TelopSegmentMerger _segmentMerger = new();
+    private readonly ExportPackageWriter _exportPackageWriter = new();
     private IReadOnlyList<FrameAnalysisResult> _latestFrameAnalyses = Array.Empty<FrameAnalysisResult>();
+    private IReadOnlyList<SegmentRecord> _latestSegments = Array.Empty<SegmentRecord>();
+    private ExportWriteResult? _latestExport;
 
     public MainPageViewModel()
     {
@@ -83,6 +88,9 @@ public partial class MainPageViewModel : ObservableObject
     public partial string OcrEngineText { get; set; } = "-";
 
     [ObservableProperty]
+    public partial string ExportDirectoryText { get; set; } = "-";
+
+    [ObservableProperty]
     public partial TimelineSegment? SelectedTimelineSegment { get; set; }
 
     public string SelectedSegmentSummary =>
@@ -152,6 +160,7 @@ public partial class MainPageViewModel : ObservableObject
 
         try
         {
+            var stopwatch = Stopwatch.StartNew();
             var metadata = await _videoProcessingService.ReadMetadataAsync(VideoPath);
             var progress = new Progress<double>(value => ProgressValue = value * 0.6d);
             var intervalSeconds = ParseFrameIntervalSeconds();
@@ -164,64 +173,43 @@ public partial class MainPageViewModel : ObservableObject
 
             var ocrProgress = new Progress<double>(value => ProgressValue = 60d + (value * 0.4d));
             _latestFrameAnalyses = await _frameAnalysisService.AnalyzeFramesAsync(result, ocrProgress);
+            _latestSegments = _segmentMerger.Merge(_latestFrameAnalyses, intervalSeconds);
 
             TimelineSegments.Clear();
             ResultRows.Clear();
 
-            var detectionCount = 0;
-            var errorCount = 0;
-            foreach (var analysis in _latestFrameAnalyses)
-            {
-                var timeLabel = FormatTimestamp(analysis.Frame.TimestampMs);
-                if (analysis.Ocr.Status == "error")
-                {
-                    errorCount++;
-                    TimelineSegments.Add(new TimelineSegment(timeLabel, $"Frame {analysis.Frame.FrameIndex:D6}", "OCR error"));
-                    ResultRows.Add(new ResultRow(
-                        timeLabel,
-                        "Error",
-                        analysis.Ocr.Error?.Code ?? "OCR_PROCESS_FAILED",
-                        analysis.Ocr.Error?.Message ?? "OCR worker failed."));
-                    continue;
-                }
+            var detectionCount = _latestFrameAnalyses.Sum(analysis => analysis.Attributes.Detections.Count);
+            var errorCount = _latestFrameAnalyses.Count(analysis => analysis.Ocr.Status == "error");
+            var warningCount = _latestFrameAnalyses.Count(analysis => analysis.Ocr.Status == "warning");
+            PopulateTimelineAndResults(_latestFrameAnalyses, _latestSegments);
 
-                if (analysis.Attributes.Detections.Count == 0)
-                {
-                    TimelineSegments.Add(new TimelineSegment(timeLabel, $"Frame {analysis.Frame.FrameIndex:D6}", "No telop detected"));
-                    ResultRows.Add(new ResultRow(
-                        timeLabel,
-                        "OCR",
-                        "No text detected",
-                        Path.GetFileName(analysis.Frame.ImagePath)));
-                    continue;
-                }
-
-                foreach (var detection in analysis.Attributes.Detections)
-                {
-                    detectionCount++;
-                    TimelineSegments.Add(new TimelineSegment(timeLabel, detection.Text, FormatStyleSummary(detection)));
-                    ResultRows.Add(new ResultRow(
-                        timeLabel,
-                        detection.TextType,
-                        detection.Text,
-                        FormatDetectionDetail(detection)));
-                }
-            }
+            stopwatch.Stop();
+            _latestExport = await _exportPackageWriter.WriteAsync(
+                metadata,
+                result,
+                _latestFrameAnalyses,
+                _latestSegments,
+                intervalSeconds,
+                OcrEngineText,
+                stopwatch.ElapsedMilliseconds,
+                warningCount,
+                errorCount);
+            ExportDirectoryText = _latestExport.OutputDirectory;
 
             SelectedTimelineSegment = TimelineSegments.FirstOrDefault();
-            PreviewState = result.Frames.Count > 0 ? $"Analyzed {result.Frames.Count} frames" : "No frames extracted";
-            ActivityMessage = $"Saved {result.Frames.Count} frames and {detectionCount} detections under {result.RunDirectory}.";
+            PreviewState = _latestSegments.Count > 0 ? $"Created {_latestSegments.Count} segments" : "No telop segments";
+            ActivityMessage = $"Saved {result.Frames.Count} frames, {detectionCount} detections, and {_latestSegments.Count} segments to {_latestExport.OutputDirectory}.";
             StatusMessage = errorCount == 0
-                ? $"Frame extraction and OCR completed. Run ID: {result.RunId}"
-                : $"Frame extraction completed with {errorCount} OCR error(s). Run ID: {result.RunId}";
+                ? $"Analysis and export completed. Run ID: {result.RunId}"
+                : $"Analysis exported with {errorCount} OCR error(s). Run ID: {result.RunId}";
 
-            RefreshInfoCards(metadata, result.Frames.Count, detectionCount);
+            RefreshInfoCards(metadata, result.Frames.Count, detectionCount, _latestSegments.Count);
         }
         catch (Exception ex)
         {
-            PreviewState = "Extraction failed";
+            PreviewState = "Analysis failed";
             ActivityMessage = ex.Message;
-            StatusMessage = "Frame extraction failed.";
+            StatusMessage = "Analysis or export failed.";
         }
         finally
         {
@@ -238,7 +226,9 @@ public partial class MainPageViewModel : ObservableObject
     [RelayCommand]
     private void OpenExport()
     {
-        StatusMessage = "Export window will be implemented later as a non-modal child window.";
+        StatusMessage = _latestExport is null
+            ? "Run analysis before opening export details."
+            : $"Latest export: {_latestExport.JsonPath}";
     }
 
     private async Task LoadVideoAsync(string path)
@@ -258,12 +248,15 @@ public partial class MainPageViewModel : ObservableObject
             CodecText = metadata.Codec;
             WorkDirectoryText = "-";
             OcrEngineText = _frameAnalysisService.EngineName;
+            ExportDirectoryText = "-";
             _latestFrameAnalyses = Array.Empty<FrameAnalysisResult>();
+            _latestSegments = Array.Empty<SegmentRecord>();
+            _latestExport = null;
             PreviewState = "Ready";
             StatusMessage = $"Loaded {metadata.FileName}";
             ActivityMessage = "Metadata loaded. You can now run frame extraction.";
 
-            RefreshInfoCards(metadata, 0, 0);
+            RefreshInfoCards(metadata, 0, 0, 0);
             TimelineSegments.Clear();
             ResultRows.Clear();
             TimelineSegments.Add(new TimelineSegment("preview", metadata.FileName, "metadata loaded"));
@@ -293,7 +286,8 @@ public partial class MainPageViewModel : ObservableObject
     private void ResetDynamicCollections()
     {
         OcrEngineText = _frameAnalysisService.EngineName;
-        RefreshInfoCards(null, 0, 0);
+        ExportDirectoryText = "-";
+        RefreshInfoCards(null, 0, 0, 0);
         TimelineSegments.Clear();
         ResultRows.Clear();
         TimelineSegments.Add(new TimelineSegment("timeline", "No frames yet", "load a video to begin"));
@@ -301,27 +295,68 @@ public partial class MainPageViewModel : ObservableObject
         SelectedTimelineSegment = TimelineSegments[0];
     }
 
-    private void RefreshInfoCards(VideoMetadata? metadata, int frameCount, int detectionCount)
+    private void RefreshInfoCards(VideoMetadata? metadata, int frameCount, int detectionCount, int segmentCount)
     {
         InfoCards.Clear();
         InfoCards.Add(new InfoCardItem("Video", metadata?.FileName ?? "Not selected", "Current source video"));
         InfoCards.Add(new InfoCardItem("Frames", frameCount.ToString(), "Extracted frame count"));
         InfoCards.Add(new InfoCardItem("OCR", $"{detectionCount} detections", OcrEngineText));
+        InfoCards.Add(new InfoCardItem("Segments", segmentCount.ToString(), "Merged telop segments"));
+        InfoCards.Add(new InfoCardItem("Export", ExportDirectoryText, "JSON and CSV output directory"));
         InfoCards.Add(new InfoCardItem("Work", WorkDirectoryText, "Current output directory"));
     }
 
-    private static string FormatStyleSummary(TelopAttributeRecord detection)
+    private void PopulateTimelineAndResults(
+        IReadOnlyList<FrameAnalysisResult> frameAnalyses,
+        IReadOnlyList<SegmentRecord> segments)
     {
-        var fontSize = detection.FontSize is null ? "size unknown" : $"{detection.FontSize:F1}{detection.FontSizeUnit}";
-        return $"{detection.TextType} / {fontSize}";
+        if (segments.Count > 0)
+        {
+            foreach (var segment in segments)
+            {
+                var rangeLabel = $"{FormatTimestamp(segment.StartTimestampMs)} - {FormatTimestamp(segment.EndTimestampMs)}";
+                TimelineSegments.Add(new TimelineSegment(rangeLabel, segment.Text, FormatSegmentStyleSummary(segment)));
+                ResultRows.Add(new ResultRow(rangeLabel, segment.TextType, segment.Text, FormatSegmentDetail(segment)));
+            }
+
+            return;
+        }
+
+        foreach (var analysis in frameAnalyses)
+        {
+            var timeLabel = FormatTimestamp(analysis.Frame.TimestampMs);
+            if (analysis.Ocr.Status == "error")
+            {
+                TimelineSegments.Add(new TimelineSegment(timeLabel, $"Frame {analysis.Frame.FrameIndex:D6}", "OCR error"));
+                ResultRows.Add(new ResultRow(
+                    timeLabel,
+                    "Error",
+                    analysis.Ocr.Error?.Code ?? "OCR_PROCESS_FAILED",
+                    analysis.Ocr.Error?.Message ?? "OCR worker failed."));
+                continue;
+            }
+
+            TimelineSegments.Add(new TimelineSegment(timeLabel, $"Frame {analysis.Frame.FrameIndex:D6}", "No telop detected"));
+            ResultRows.Add(new ResultRow(
+                timeLabel,
+                "OCR",
+                "No text detected",
+                Path.GetFileName(analysis.Frame.ImagePath)));
+        }
     }
 
-    private static string FormatDetectionDetail(TelopAttributeRecord detection)
+    private static string FormatSegmentStyleSummary(SegmentRecord segment)
     {
-        var confidence = detection.Confidence is null ? "confidence unknown" : $"confidence {detection.Confidence:P1}";
+        var fontSize = segment.FontSize is null ? "size unknown" : $"{segment.FontSize:F1}{segment.FontSizeUnit}";
+        return $"{segment.TextType} / {fontSize} / {segment.SourceFrameCount} frame(s)";
+    }
+
+    private static string FormatSegmentDetail(SegmentRecord segment)
+    {
+        var confidence = segment.Confidence is null ? "confidence unknown" : $"confidence {segment.Confidence:P1}";
         var colors = string.Join(
             " / ",
-            new[] { detection.TextColor, detection.StrokeColor, detection.BackgroundColor }
+            new[] { segment.TextColor, segment.StrokeColor, segment.BackgroundColor }
                 .Where(value => !string.IsNullOrWhiteSpace(value)));
 
         return string.IsNullOrWhiteSpace(colors)


### PR DESCRIPTION
## 概要
- OCR/属性解析済みフレームから `SegmentRecord` を生成する `TelopSegmentMerger` を追加
- セグメント中心のタイムライン/結果一覧表示へ更新
- `ExportPackageWriter` を追加し、`work/runs/<run_id>/output/segments.json`、`segments.csv`、`frames.csv` を生成
- Export ボタンの暫定動作として最新 `segments.json` パスをステータスに表示
- README、出力仕様、処理パイプライン詳細設計、データモデル詳細設計、実装メモを更新

## 検証
- `dotnet build src/MovieTelopTranscriber.sln -p:Platform=x64`

Closes #33