### PR TITLE
実行ログとラン単位ディレクトリ管理を実装する

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,5 @@
 - 未指定時はフレーム同名の `.ocr.json` サイドカーを読み込み、サイドカーがない場合は空検出として処理を継続する。
 - 中間成果物は `work/runs/<run_id>/frames`、`ocr`、`attributes` に分けて保存する。
 - 最終成果物は `work/runs/<run_id>/output/segments.json`、`segments.csv`、`frames.csv` として保存する。
+- 実行ログは `work/runs/<run_id>/logs/run.log` と `summary.json` として保存する。
 - 設定画面と出力画面は非モーダル子ウィンドウとして開き、メイン画面と同じ状態を参照する。

--- a/docs/07_実装メモ.md
+++ b/docs/07_実装メモ.md
@@ -21,6 +21,7 @@
 - フレーム画像: `work/runs/<run_id>/frames/`
 - OCR リクエストとレスポンス: `work/runs/<run_id>/ocr/`
 - 属性解析結果: `work/runs/<run_id>/attributes/`
+- 実行ログ: `work/runs/<run_id>/logs/`
 
 ## 5. セグメント統合と出力
 - `TelopSegmentMerger` が、同一文字列・同一属性キーの連続フレームを 1 セグメントへ統合する。
@@ -35,10 +36,16 @@
 - `SettingsWindow` と `ExportWindow` を独立した WinUI `Window` として実装する。
 - どちらもメイン画面と同じ `MainPageViewModel` を参照する。
 - 設定画面は抽出間隔を双方向同期し、現在の設定サマリを表示する。
-- 出力画面は出力ディレクトリ、JSON / CSV パス、最新結果一覧を表示する。
+- 出力画面は出力ディレクトリ、JSON / CSV パス、ログパス、最新結果一覧を表示する。
 - 再オープン時は、閉じられていない既存ウィンドウを再利用して前面化する。
 
-## 7. 後続工程で再評価する項目
+## 7. ラン単位ログ
+- `RunLogWriter` が `logs/run.log` と `logs/summary.json` を生成する。
+- `run.log` は人が確認しやすい key-value 形式とする。
+- `summary.json` は機械処理しやすい JSON 形式とする。
+- ログには入力動画、設定、件数、警告/エラー数、成果物パスを記録する。
+
+## 8. 後続工程で再評価する項目
 - PaddleOCR / Tesseract / Windows 標準 OCR の採用実体。
 - OCR モデルや外部ランタイムを配布物へ同梱する範囲。
 - 色属性推定の画像解析方式。

--- a/docs/design/04_処理パイプライン詳細設計.md
+++ b/docs/design/04_処理パイプライン詳細設計.md
@@ -202,6 +202,7 @@ OCR ワーカー連携、処理順序、I/O 契約、エラー返却、再実行
 - フレーム画像: `work/runs/<run_id>/frames/`
 - OCR リクエストとレスポンス: `work/runs/<run_id>/ocr/`
 - 属性解析結果: `work/runs/<run_id>/attributes/`
+- 実行ログ: `work/runs/<run_id>/logs/`
 - 外部ワーカー未設定時も、同じ配置規約でリクエストとレスポンスを保存する。
 
 ### 7.4 初期実装の最終成果物
@@ -209,6 +210,11 @@ OCR ワーカー連携、処理順序、I/O 契約、エラー返却、再実行
 - セグメント CSV: `work/runs/<run_id>/output/segments.csv`
 - フレーム CSV: `work/runs/<run_id>/output/frames.csv`
 - 出力ファイルは OCR 検出がない場合も生成する。
+
+### 7.5 初期実装のログ成果物
+- 実行ログ: `work/runs/<run_id>/logs/run.log`
+- 実行要約: `work/runs/<run_id>/logs/summary.json`
+- ログには `run_id`、開始/終了時刻、入力動画、抽出間隔、OCR エンジン、フレーム数、検出数、セグメント数、警告数、エラー数、成果物パスを記録する。
 
 ### 7.2 ログ粒度
 - 実行単位ログ

--- a/docs/design/05_データモデル詳細設計.md
+++ b/docs/design/05_データモデル詳細設計.md
@@ -28,6 +28,8 @@
 - `ProcessingSettingsRecord`: 出力に残す実行設定を保持する。
 - `RunMetadataRecord`: 出力生成時刻、アプリバージョン、処理時間、警告/エラー件数を保持する。
 - `ExportWriteResult`: 生成した JSON / CSV ファイルパスを保持する。
+- `RunSummaryRecord`: ラン単位ログの要約を保持する。
+- `RunLogWriteResult`: 生成したログファイルと要約ファイルのパスを保持する。
 - `ProcessingError`: 失敗コード、表示メッセージ、詳細、再実行可否を保持する。
 
 ## 2. 内部モデルと出力モデルの対応
@@ -82,6 +84,8 @@
 - 実行ログは `logs/` へ保存する。
 
 初期実装では、OCR リクエストとレスポンスを `ocr/` に JSON として保存し、属性解析結果を `attributes/` に JSON として保存する。これにより、外部 OCR ワーカーの導入前でも I/O 契約と GUI 連携を確認できる。
+
+ログは `logs/run.log` と `logs/summary.json` に保存する。GUI からは出力画面でログファイルと要約ファイルのパスを確認できる。
 
 ### 5.3 最終成果物の保存方針
 - JSON は `segments.json` を標準名とする。

--- a/docs/spec/04_出力仕様.md
+++ b/docs/spec/04_出力仕様.md
@@ -178,5 +178,7 @@
 - `segments.json`: 入力動画、処理設定、フレーム単位検出、セグメント単位結果、実行メタデータを含む。
 - `segments.csv`: セグメント単位の確認用 CSV。
 - `frames.csv`: フレーム単位の確認用 CSV。
+- `logs/run.log`: ラン単位の人間向け実行ログ。
+- `logs/summary.json`: ラン単位の機械可読な実行要約。
 - OCR 検出が 0 件の場合も、JSON と CSV は生成する。
-- GUI の Export ボタンは、非モーダル出力画面実装前の暫定動作として最新 `segments.json` のパスをステータス表示する。
+- GUI の Export ボタンは、非モーダル出力画面を開き、JSON / CSV / ログの各パスと最新結果一覧を表示する。

--- a/src/MovieTelopTranscriber.App/ExportWindow.xaml
+++ b/src/MovieTelopTranscriber.App/ExportWindow.xaml
@@ -40,6 +40,16 @@
                 IsReadOnly="True"
                 Text="{x:Bind ViewModel.FramesCsvOutputPathText, Mode=OneWay}"
                 TextWrapping="Wrap" />
+            <TextBox
+                Header="Run log"
+                IsReadOnly="True"
+                Text="{x:Bind ViewModel.RunLogPathText, Mode=OneWay}"
+                TextWrapping="Wrap" />
+            <TextBox
+                Header="Run summary"
+                IsReadOnly="True"
+                Text="{x:Bind ViewModel.RunSummaryPathText, Mode=OneWay}"
+                TextWrapping="Wrap" />
         </StackPanel>
 
         <Grid Grid.Row="2">

--- a/src/MovieTelopTranscriber.App/Models/RunLogWriteResult.cs
+++ b/src/MovieTelopTranscriber.App/Models/RunLogWriteResult.cs
@@ -1,0 +1,6 @@
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record RunLogWriteResult(
+    string LogsDirectory,
+    string LogPath,
+    string SummaryPath);

--- a/src/MovieTelopTranscriber.App/Models/RunSummaryRecord.cs
+++ b/src/MovieTelopTranscriber.App/Models/RunSummaryRecord.cs
@@ -1,0 +1,20 @@
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record RunSummaryRecord(
+    string RunId,
+    DateTimeOffset StartedAt,
+    DateTimeOffset CompletedAt,
+    string Status,
+    string SourceVideoPath,
+    double FrameIntervalSeconds,
+    string OcrEngine,
+    int FrameCount,
+    int DetectionCount,
+    int SegmentCount,
+    int WarningCount,
+    int ErrorCount,
+    string WorkDirectory,
+    string OutputDirectory,
+    string JsonPath,
+    string SegmentsCsvPath,
+    string FramesCsvPath);

--- a/src/MovieTelopTranscriber.App/Services/RunLogWriter.cs
+++ b/src/MovieTelopTranscriber.App/Services/RunLogWriter.cs
@@ -1,0 +1,81 @@
+using System.Text;
+using System.Text.Json;
+using MovieTelopTranscriber.App.Models;
+
+namespace MovieTelopTranscriber.App.Services;
+
+public sealed class RunLogWriter
+{
+    public async Task<RunLogWriteResult> WriteSuccessAsync(
+        FrameExtractionResult frameExtractionResult,
+        VideoMetadata sourceVideo,
+        ExportWriteResult exportWriteResult,
+        double frameIntervalSeconds,
+        string ocrEngine,
+        DateTimeOffset startedAt,
+        DateTimeOffset completedAt,
+        int frameCount,
+        int detectionCount,
+        int segmentCount,
+        int warningCount,
+        int errorCount,
+        CancellationToken cancellationToken = default)
+    {
+        var logsDirectory = Path.Combine(frameExtractionResult.RunDirectory, "logs");
+        Directory.CreateDirectory(logsDirectory);
+
+        var status = errorCount > 0 ? "warning" : "success";
+        var summary = new RunSummaryRecord(
+            frameExtractionResult.RunId,
+            startedAt,
+            completedAt,
+            status,
+            sourceVideo.FilePath,
+            frameIntervalSeconds,
+            ocrEngine,
+            frameCount,
+            detectionCount,
+            segmentCount,
+            warningCount,
+            errorCount,
+            frameExtractionResult.RunDirectory,
+            exportWriteResult.OutputDirectory,
+            exportWriteResult.JsonPath,
+            exportWriteResult.SegmentsCsvPath,
+            exportWriteResult.FramesCsvPath);
+
+        var summaryPath = Path.Combine(logsDirectory, "summary.json");
+        await using (var stream = File.Create(summaryPath))
+        {
+            await JsonSerializer.SerializeAsync(stream, summary, OcrContractJson.Options, cancellationToken);
+        }
+
+        var logPath = Path.Combine(logsDirectory, "run.log");
+        await File.WriteAllTextAsync(logPath, BuildRunLog(summary), new UTF8Encoding(false), cancellationToken);
+
+        return new RunLogWriteResult(logsDirectory, logPath, summaryPath);
+    }
+
+    private static string BuildRunLog(RunSummaryRecord summary)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"run_id={summary.RunId}");
+        builder.AppendLine($"status={summary.Status}");
+        builder.AppendLine($"started_at={summary.StartedAt:O}");
+        builder.AppendLine($"completed_at={summary.CompletedAt:O}");
+        builder.AppendLine($"source_video={summary.SourceVideoPath}");
+        builder.AppendLine($"frame_interval_seconds={summary.FrameIntervalSeconds}");
+        builder.AppendLine($"ocr_engine={summary.OcrEngine}");
+        builder.AppendLine($"frame_count={summary.FrameCount}");
+        builder.AppendLine($"detection_count={summary.DetectionCount}");
+        builder.AppendLine($"segment_count={summary.SegmentCount}");
+        builder.AppendLine($"warning_count={summary.WarningCount}");
+        builder.AppendLine($"error_count={summary.ErrorCount}");
+        builder.AppendLine($"work_directory={summary.WorkDirectory}");
+        builder.AppendLine($"output_directory={summary.OutputDirectory}");
+        builder.AppendLine($"json_path={summary.JsonPath}");
+        builder.AppendLine($"segments_csv_path={summary.SegmentsCsvPath}");
+        builder.AppendLine($"frames_csv_path={summary.FramesCsvPath}");
+        return builder.ToString();
+    }
+}

--- a/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
+++ b/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
@@ -14,6 +14,7 @@ public partial class MainPageViewModel : ObservableObject
     private readonly TelopFrameAnalysisService _frameAnalysisService = new();
     private readonly TelopSegmentMerger _segmentMerger = new();
     private readonly ExportPackageWriter _exportPackageWriter = new();
+    private readonly RunLogWriter _runLogWriter = new();
     private IReadOnlyList<FrameAnalysisResult> _latestFrameAnalyses = Array.Empty<FrameAnalysisResult>();
     private IReadOnlyList<SegmentRecord> _latestSegments = Array.Empty<SegmentRecord>();
     private ExportWriteResult? _latestExport;
@@ -104,6 +105,15 @@ public partial class MainPageViewModel : ObservableObject
     public partial string FramesCsvOutputPathText { get; set; } = "-";
 
     [ObservableProperty]
+    public partial string LogDirectoryText { get; set; } = "-";
+
+    [ObservableProperty]
+    public partial string RunLogPathText { get; set; } = "-";
+
+    [ObservableProperty]
+    public partial string RunSummaryPathText { get; set; } = "-";
+
+    [ObservableProperty]
     public partial TimelineSegment? SelectedTimelineSegment { get; set; }
 
     public string SelectedSegmentSummary =>
@@ -173,6 +183,7 @@ public partial class MainPageViewModel : ObservableObject
 
         try
         {
+            var startedAt = DateTimeOffset.Now;
             var stopwatch = Stopwatch.StartNew();
             var metadata = await _videoProcessingService.ReadMetadataAsync(VideoPath);
             var progress = new Progress<double>(value => ProgressValue = value * 0.6d);
@@ -212,9 +223,26 @@ public partial class MainPageViewModel : ObservableObject
             SegmentsCsvOutputPathText = _latestExport.SegmentsCsvPath;
             FramesCsvOutputPathText = _latestExport.FramesCsvPath;
 
+            var logWriteResult = await _runLogWriter.WriteSuccessAsync(
+                result,
+                metadata,
+                _latestExport,
+                intervalSeconds,
+                OcrEngineText,
+                startedAt,
+                DateTimeOffset.Now,
+                result.Frames.Count,
+                detectionCount,
+                _latestSegments.Count,
+                warningCount,
+                errorCount);
+            LogDirectoryText = logWriteResult.LogsDirectory;
+            RunLogPathText = logWriteResult.LogPath;
+            RunSummaryPathText = logWriteResult.SummaryPath;
+
             SelectedTimelineSegment = TimelineSegments.FirstOrDefault();
             PreviewState = _latestSegments.Count > 0 ? $"Created {_latestSegments.Count} segments" : "No telop segments";
-            ActivityMessage = $"Saved {result.Frames.Count} frames, {detectionCount} detections, and {_latestSegments.Count} segments to {_latestExport.OutputDirectory}.";
+            ActivityMessage = $"Saved {result.Frames.Count} frames, {detectionCount} detections, {_latestSegments.Count} segments, and run logs under {result.RunDirectory}.";
             StatusMessage = errorCount == 0
                 ? $"Analysis and export completed. Run ID: {result.RunId}"
                 : $"Analysis exported with {errorCount} OCR error(s). Run ID: {result.RunId}";
@@ -270,6 +298,9 @@ public partial class MainPageViewModel : ObservableObject
             JsonOutputPathText = "-";
             SegmentsCsvOutputPathText = "-";
             FramesCsvOutputPathText = "-";
+            LogDirectoryText = "-";
+            RunLogPathText = "-";
+            RunSummaryPathText = "-";
             _latestFrameAnalyses = Array.Empty<FrameAnalysisResult>();
             _latestSegments = Array.Empty<SegmentRecord>();
             _latestExport = null;
@@ -311,6 +342,9 @@ public partial class MainPageViewModel : ObservableObject
         JsonOutputPathText = "-";
         SegmentsCsvOutputPathText = "-";
         FramesCsvOutputPathText = "-";
+        LogDirectoryText = "-";
+        RunLogPathText = "-";
+        RunSummaryPathText = "-";
         RefreshInfoCards(null, 0, 0, 0);
         TimelineSegments.Clear();
         ResultRows.Clear();
@@ -327,6 +361,7 @@ public partial class MainPageViewModel : ObservableObject
         InfoCards.Add(new InfoCardItem("OCR", $"{detectionCount} detections", OcrEngineText));
         InfoCards.Add(new InfoCardItem("Segments", segmentCount.ToString(), "Merged telop segments"));
         InfoCards.Add(new InfoCardItem("Export", ExportDirectoryText, "JSON and CSV output directory"));
+        InfoCards.Add(new InfoCardItem("Log", LogDirectoryText, "Run log directory"));
         InfoCards.Add(new InfoCardItem("Work", WorkDirectoryText, "Current output directory"));
     }
 


### PR DESCRIPTION
## 概要
- `RunLogWriter` を追加し、`work/runs/<run_id>/logs/run.log` と `summary.json` を生成
- ラン要約に入力動画、抽出間隔、OCR エンジン、件数、警告/エラー数、成果物パスを記録
- ViewModel にログディレクトリ、ログファイル、要約ファイルのパスを追加
- 出力ウィンドウと InfoCard からログ/成果物パスを確認できるように更新
- README、出力仕様、処理パイプライン詳細設計、データモデル詳細設計、実装メモを更新

## 検証
- `dotnet build src/MovieTelopTranscriber.sln -p:Platform=x64`

Closes #40