### PR TITLE
ReleaseビルドのJSONシリアライズをsource generationへ切り替える

### DIFF
--- a/docs/test-results/2026-04-28_オフライン導入実行検証.md
+++ b/docs/test-results/2026-04-28_オフライン導入実行検証.md
@@ -49,16 +49,33 @@ Start-Process `
 - 起動継続を確認した。
 - #46 の現時点の手動確認は、この Release build 出力を使って継続する。
 
+### 2.3 Release build 出力での抽出実行
+ユーザー手動確認で、`抽出` 実行後に進捗インジケータが途中停止し、処理状況に以下で始まるエラーが表示された。
+
+```text
+Reflection-based serialization has been disabled
+```
+
+確認結果:
+- `work/runs/20260428_153626_7e5a/ocr/ocr-000001-00000000ms.request.json` が 0 byte で生成されていた。
+- フレーム抽出後、最初の OCR request JSON を書き出す時点で `System.Text.Json` の reflection fallback が使われ、Release 実行時に停止していた。
+
+対処:
+- OCR request / response、属性解析結果、出力 package、run summary の JSON 入出力を `JsonSerializerOptions` ではなく source generation の `JsonTypeInfo<T>` に切り替えた。
+- Release ビルドで `System.Text.Json` の reflection-based serialization 警告が出ないことを確認した。
+
 ## 3. 判断
 - self-contained publish 出力は起動失敗するため、現時点のオフライン導入候補としては未成立。
 - Release build 出力は起動できるため、ローカル実行確認と手順洗い出しには利用できる。
 - Release build 出力は .NET / Windows App SDK などの実行前提を利用環境側に要求する可能性があるため、同梱物とランタイム要件は #46 / #47 / リリース工程で整理する。
+- Release build 出力での抽出停止は JSON source generation 対応により解消見込み。ユーザー環境での再抽出確認をもって #46 の実行確認を継続する。
 
 ## 4. 未完了の確認
 以下は引き続き #46 で確認する。
 
 - ネットワーク切断状態で起動できること。
 - サンプル動画を選択し、解析から出力まで実行できること。
+- `抽出` 実行後に `Reflection-based serialization has been disabled` が再発しないこと。
 - `work/runs/<run_id>/frames`、`ocr`、`attributes`、`output`、`logs` が生成されること。
 - 出力パス、ログパス、設定画面の表示内容が publish 配置でも確認できること。
 - 導入手順に必要なランタイム、同梱物、既知制約を整理すること。

--- a/src/MovieTelopTranscriber.App/Services/ExportPackageWriter.cs
+++ b/src/MovieTelopTranscriber.App/Services/ExportPackageWriter.cs
@@ -45,7 +45,7 @@ public sealed class ExportPackageWriter
         var jsonPath = Path.Combine(outputDirectory, "segments.json");
         await using (var stream = File.Create(jsonPath))
         {
-            await JsonSerializer.SerializeAsync(stream, package, OcrContractJson.Options, cancellationToken);
+            await JsonSerializer.SerializeAsync(stream, package, OcrContractJson.ExportPackage, cancellationToken);
         }
 
         var segmentsCsvPath = Path.Combine(outputDirectory, "segments.csv");

--- a/src/MovieTelopTranscriber.App/Services/OcrContractJson.cs
+++ b/src/MovieTelopTranscriber.App/Services/OcrContractJson.cs
@@ -1,12 +1,39 @@
-using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using MovieTelopTranscriber.App.Models;
 
 namespace MovieTelopTranscriber.App.Services;
 
 internal static class OcrContractJson
 {
-    public static JsonSerializerOptions Options { get; } = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
-        WriteIndented = true
-    };
+    public static JsonTypeInfo<AttributeAnalysisResult> AttributeAnalysisResult => OcrJsonSerializerContext.Default.AttributeAnalysisResult;
+
+    public static JsonTypeInfo<ExportPackage> ExportPackage => OcrJsonSerializerContext.Default.ExportPackage;
+
+    public static JsonTypeInfo<OcrWorkerRequest> OcrWorkerRequest => OcrJsonSerializerContext.Default.OcrWorkerRequest;
+
+    public static JsonTypeInfo<OcrWorkerResponse> OcrWorkerResponse => OcrJsonSerializerContext.Default.OcrWorkerResponse;
+
+    public static JsonTypeInfo<RunSummaryRecord> RunSummaryRecord => OcrJsonSerializerContext.Default.RunSummaryRecord;
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(AttributeAnalysisResult))]
+[JsonSerializable(typeof(ExportPackage))]
+[JsonSerializable(typeof(FrameExportRecord))]
+[JsonSerializable(typeof(OcrBoundingPoint))]
+[JsonSerializable(typeof(OcrDetectionRecord))]
+[JsonSerializable(typeof(OcrWorkerRequest))]
+[JsonSerializable(typeof(OcrWorkerResponse))]
+[JsonSerializable(typeof(ProcessingError))]
+[JsonSerializable(typeof(ProcessingSettingsRecord))]
+[JsonSerializable(typeof(RunMetadataRecord))]
+[JsonSerializable(typeof(RunSummaryRecord))]
+[JsonSerializable(typeof(SegmentRecord))]
+[JsonSerializable(typeof(TelopAttributeRecord))]
+[JsonSerializable(typeof(VideoMetadata))]
+internal sealed partial class OcrJsonSerializerContext : JsonSerializerContext
+{
 }

--- a/src/MovieTelopTranscriber.App/Services/ProcessOcrWorkerClient.cs
+++ b/src/MovieTelopTranscriber.App/Services/ProcessOcrWorkerClient.cs
@@ -137,9 +137,9 @@ public sealed class ProcessOcrWorkerClient : IOcrWorkerClient
         try
         {
             await using var stream = File.OpenRead(responsePath);
-            var response = await JsonSerializer.DeserializeAsync<OcrWorkerResponse>(
+            var response = await JsonSerializer.DeserializeAsync(
                 stream,
-                OcrContractJson.Options,
+                OcrContractJson.OcrWorkerResponse,
                 cancellationToken);
 
             if (response is null)
@@ -165,10 +165,16 @@ public sealed class ProcessOcrWorkerClient : IOcrWorkerClient
         }
     }
 
-    private static async Task WriteJsonAsync<T>(string path, T value, CancellationToken cancellationToken)
+    private static async Task WriteJsonAsync(string path, OcrWorkerRequest value, CancellationToken cancellationToken)
     {
         await using var stream = File.Create(path);
-        await JsonSerializer.SerializeAsync(stream, value, OcrContractJson.Options, cancellationToken);
+        await JsonSerializer.SerializeAsync(stream, value, OcrContractJson.OcrWorkerRequest, cancellationToken);
+    }
+
+    private static async Task WriteJsonAsync(string path, OcrWorkerResponse value, CancellationToken cancellationToken)
+    {
+        await using var stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, value, OcrContractJson.OcrWorkerResponse, cancellationToken);
     }
 
     private static OcrWorkerResponse CreateErrorResponse(

--- a/src/MovieTelopTranscriber.App/Services/RunLogWriter.cs
+++ b/src/MovieTelopTranscriber.App/Services/RunLogWriter.cs
@@ -47,7 +47,7 @@ public sealed class RunLogWriter
         var summaryPath = Path.Combine(logsDirectory, "summary.json");
         await using (var stream = File.Create(summaryPath))
         {
-            await JsonSerializer.SerializeAsync(stream, summary, OcrContractJson.Options, cancellationToken);
+            await JsonSerializer.SerializeAsync(stream, summary, OcrContractJson.RunSummaryRecord, cancellationToken);
         }
 
         var logPath = Path.Combine(logsDirectory, "run.log");

--- a/src/MovieTelopTranscriber.App/Services/TelopFrameAnalysisService.cs
+++ b/src/MovieTelopTranscriber.App/Services/TelopFrameAnalysisService.cs
@@ -70,7 +70,7 @@ public sealed class TelopFrameAnalysisService
     {
         var path = Path.Combine(attributesDirectory, $"{requestId}.attributes.json");
         await using var stream = File.Create(path);
-        await JsonSerializer.SerializeAsync(stream, attributeResult, OcrContractJson.Options, cancellationToken);
+        await JsonSerializer.SerializeAsync(stream, attributeResult, OcrContractJson.AttributeAnalysisResult, cancellationToken);
     }
 
     private static string CreateRequestId(ExtractedFrameRecord frame)


### PR DESCRIPTION
## 概要
- Releaseビルドで抽出実行時に `Reflection-based serialization has been disabled` が発生する問題に対応しました。
- OCR request / response、属性解析結果、出力package、run summary のJSON入出力を source generation の `JsonTypeInfo<T>` 経由に統一しました。
- #46 の検証記録に、再現状況と今回の対処を追記しました。

## 確認
- `dotnet build src\MovieTelopTranscriber.sln -p:Platform=x64`
- `dotnet build src\MovieTelopTranscriber.App\MovieTelopTranscriber.App.csproj -c Release -p:Platform=x64`
- `git diff --check`
- `rg --line-number "効く" . -S` で該当なし

Refs #46