### PR TITLE
#46の抽出再実行成功結果を検証記録へ反映する

### DIFF
--- a/docs/test-results/2026-04-28_オフライン導入実行検証.md
+++ b/docs/test-results/2026-04-28_オフライン導入実行検証.md
@@ -64,18 +64,30 @@ Reflection-based serialization has been disabled
 - OCR request / response、属性解析結果、出力 package、run summary の JSON 入出力を `JsonSerializerOptions` ではなく source generation の `JsonTypeInfo<T>` に切り替えた。
 - Release ビルドで `System.Text.Json` の reflection-based serialization 警告が出ないことを確認した。
 
+### 2.4 Release build 出力での抽出再実行
+ユーザー手動確認で、`sample_basic_telop.mp4` を選択して `抽出` を実行した。
+
+結果:
+- `Analysis and export completed. Run ID: 20260428_154821_9ed8` が表示された。
+- `Reflection-based serialization has been disabled` は再発しなかった。
+- `work/runs/20260428_154821_9ed8/logs/run.log` の `status` は `success` だった。
+- `frame_count=5`、`detection_count=0`、`segment_count=0`、`warning_count=0`、`error_count=0` を確認した。
+- `frames`、`ocr`、`attributes`、`output`、`logs` の各ディレクトリに成果物が生成された。
+
+補足:
+- サンプル動画に対する現在の OCR worker は `json-sidecar` で、検出結果 0 件として正常終了している。
+- 画面上の処理状況テキストは右ペイン幅の都合で一部見切れている。機能停止ではないが、後続の UI 調整候補とする。
+
 ## 3. 判断
 - self-contained publish 出力は起動失敗するため、現時点のオフライン導入候補としては未成立。
 - Release build 出力は起動できるため、ローカル実行確認と手順洗い出しには利用できる。
 - Release build 出力は .NET / Windows App SDK などの実行前提を利用環境側に要求する可能性があるため、同梱物とランタイム要件は #46 / #47 / リリース工程で整理する。
-- Release build 出力での抽出停止は JSON source generation 対応により解消見込み。ユーザー環境での再抽出確認をもって #46 の実行確認を継続する。
+- Release build 出力での抽出停止は JSON source generation 対応により解消した。
+- Release build 出力で、動画入力からフレーム抽出、OCR sidecar 処理、属性出力、最終出力、run log 生成までの一連実行は成立した。
 
 ## 4. 未完了の確認
 以下は引き続き #46 で確認する。
 
 - ネットワーク切断状態で起動できること。
-- サンプル動画を選択し、解析から出力まで実行できること。
-- `抽出` 実行後に `Reflection-based serialization has been disabled` が再発しないこと。
-- `work/runs/<run_id>/frames`、`ocr`、`attributes`、`output`、`logs` が生成されること。
 - 出力パス、ログパス、設定画面の表示内容が publish 配置でも確認できること。
 - 導入手順に必要なランタイム、同梱物、既知制約を整理すること。


### PR DESCRIPTION
## 概要
- Release build 出力での `抽出` 再実行成功を #46 の検証記録に追記しました。
- run `20260428_154821_9ed8` の `status=success`、5 frames、0 warnings/errors、成果物生成を記録しました。
- 画面上の処理状況テキストが右ペイン幅で見切れる点を後続 UI 調整候補として補足しました。

## 確認
- `git diff --check`
- `rg --line-number "効く" . -S` で該当なし

Refs #46