### PR TITLE
#46のOCR再実行成功結果を検証記録へ反映する

### DIFF
--- a/docs/test-results/2026-04-28_オフライン導入実行検証.md
+++ b/docs/test-results/2026-04-28_オフライン導入実行検証.md
@@ -85,6 +85,19 @@ Reflection-based serialization has been disabled
 - ネットワーク切断状態での利用に支障となる事象は確認されなかった。
 - #46 の未完了確認から、ネットワーク切断状態での起動確認を外す。
 
+### 2.6 サンプル sidecar 生成後の OCR 再実行
+直近 run `20260428_155035_e28c` の `frames` に、`test-data/basic_telop/materialize_sidecars.py` でサンプル用 `.ocr.json` を生成したうえで、ユーザー手動確認により `OCR 再実行` を実施した。
+
+結果:
+- `work/runs/20260428_155035_e28c/logs/run.log` の `status` は `success` だった。
+- `frame_count=5`、`detection_count=4`、`segment_count=2`、`warning_count=0`、`error_count=0` を確認した。
+- `segments.json` に `サンプルテロップ` と `重要なお知らせ` の 2 セグメントが出力された。
+- `サンプルテロップ` は `1000-3000ms`、`重要なお知らせ` は `3000-5000ms` のセグメントとして生成された。
+
+補足:
+- 初回抽出で `No text detected` になることは、外部 OCR worker 未設定かつ sidecar 未生成時の現行仕様と整合する。
+- sidecar 生成後の `OCR 再実行` では、サンプルデータの期待テキストが出力されることを確認した。
+
 ## 3. 判断
 - self-contained publish 出力は起動失敗するため、現時点のオフライン導入候補としては未成立。
 - Release build 出力は起動できるため、ローカル実行確認と手順洗い出しには利用できる。
@@ -92,6 +105,7 @@ Reflection-based serialization has been disabled
 - Release build 出力での抽出停止は JSON source generation 対応により解消した。
 - Release build 出力で、動画入力からフレーム抽出、OCR sidecar 処理、属性出力、最終出力、run log 生成までの一連実行は成立した。
 - ネットワーク切断状態での確認は問題なしとして扱う。
+- サンプル sidecar を生成した状態では、`OCR 再実行` により期待テキストとセグメントが出力される。
 
 ## 4. 未完了の確認
 以下は引き続き #46 で確認する。


### PR DESCRIPTION
## 概要
- サンプル sidecar 生成後の `OCR 再実行` 成功結果を #46 の検証記録へ追記しました。
- run `20260428_155035_e28c` で `4 detections`、`2 segments`、警告/エラー 0 を確認したことを記録しました。
- `サンプルテロップ` と `重要なお知らせ` のセグメント出力を確認したことを記録しました。

## 確認
- `git diff --check`
- `rg --line-number "効く" . -S` で該当なし

Refs #46