### PR TITLE
#72のWindows OCR worker baselineを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - `docs/05_詳細設計書.md`
 - `docs/06_テスト計画書.md`
 - `docs/08_既知不具合と制約一覧.md`
+- `docs/09_Windows_OCRワーカー導入手順.md`
 
 ## ディレクトリ
 - `src/`: 実装
@@ -62,6 +63,7 @@
 - OCR ワーカー接続は JSON I/O 契約で実装済み。
 - 外部 OCR ワーカーは `MOVIE_TELOP_OCR_WORKER` 環境変数で指定する。
 - 未指定時はフレーム同名の `.ocr.json` サイドカーを読み込み、サイドカーがない場合は空検出として処理を継続する。
+- Windows 標準 OCR を使う baseline worker は `src/MovieTelopTranscriber.Ocr.Windows/` に実装済み。
 - 中間成果物は `work/runs/<run_id>/frames`、`ocr`、`attributes` に分けて保存する。
 - 最終成果物は `work/runs/<run_id>/output/segments.json`、`segments.csv`、`frames.csv` として保存する。
 - 実行ログは `work/runs/<run_id>/logs/run.log` と `summary.json` として保存する。

--- a/docs/07_実装メモ.md
+++ b/docs/07_実装メモ.md
@@ -10,6 +10,8 @@
 - 外部ワーカーには `request.json` と `response.json` のパスを引数として渡す。
 - 外部ワーカー未設定時は、抽出フレームと同名の `.ocr.json` を同じ契約のレスポンスとして読み込む。
 - `.ocr.json` がない場合は空検出の `success` レスポンスを保存する。
+- Windows 標準 OCR を使う baseline worker は `MovieTelopTranscriber.Ocr.Windows` として追加済み。
+- Windows OCR worker は `Windows.Media.Ocr` を使い、行単位の検出結果を共通 OCR 契約へ変換する。
 
 ## 3. 属性解析
 - `TelopAttributeAnalysisService` が OCR レスポンスを内部属性モデルへ変換する。

--- a/docs/08_既知不具合と制約一覧.md
+++ b/docs/08_既知不具合と制約一覧.md
@@ -23,7 +23,7 @@
 ## 5. 既知制約
 | ID | 内容 | 影響 | 回避策 | 後続 Issue | リリース判断 |
 | --- | --- | --- | --- | --- | --- |
-| C-001 | 実 OCR worker はまだ同梱されていない。`MOVIE_TELOP_OCR_WORKER` 未設定時は `json-sidecar` で動作し、抽出フレームと同名の `.ocr.json` がない場合は空検出になる。 | 任意の実動画をそのまま入力しても、文字認識は成立しない。 | サンプルでは `materialize_sidecars.py` で sidecar を生成し、`OCR 再実行` を実施する。任意動画では実 OCR worker または動画専用 sidecar を用意する。 | `#72` | 実動画 OCR を初期リリース要件に含める場合、#72 完了が必要。 |
+| C-001 | `MOVIE_TELOP_OCR_WORKER` 未設定時は `json-sidecar` で動作し、抽出フレームと同名の `.ocr.json` がない場合は空検出になる。Windows OCR baseline worker は追加済みだが、精度と配布形態はリリース工程で確定する。 | worker 未設定の任意実動画では文字認識は成立しない。Windows OCR でも日本語テロップは完全一致しない場合がある。 | サンプルでは `materialize_sidecars.py` で sidecar を生成し、`OCR 再実行` を実施する。実 OCR 確認では `MovieTelopTranscriber.Ocr.Windows` を `MOVIE_TELOP_OCR_WORKER` に指定する。 | `#72` | 実動画 OCR を初期リリース要件に含める場合、#72 完了が必要。 |
 | C-002 | `materialize_sidecars.py` は `sample_basic_telop.mp4` 専用であり、任意動画の `frames/` に実行するとサンプル動画用 OCR 結果が書き込まれる。 | 任意動画の検証結果を誤って解釈する可能性がある。 | `test-data/basic_telop/README.md` の注意書きに従い、サンプル動画以外には使わない。 | 追加 Issue なし | 文書化済みの検証補助制約として扱う。 |
 | C-003 | `font_family`、`text_color`、`stroke_color`、`background_color`、精密な `text_type` は現行実装では未推定値として扱う。 | 出力スキーマには項目が存在するが、実用的な見た目分類は未成立。 | 現行リリースでは未推定値として扱い、必要に応じて後続の画像解析で補完する。 | `#75` | 初期リリース範囲と既知制約のどちらに入れるか #75 で確定する。 |
 | C-004 | `font_size` は表示フォントサイズではなく OCR 矩形の高さ相当値として推定している。 | 実フォントサイズとして扱うと解釈を誤る可能性がある。 | 導入手順、リリースノート、出力仕様で「矩形高さ相当」として説明する。 | `#75` | #75 で表記と扱いを確定する。 |
@@ -38,6 +38,6 @@
 
 ## 7. リリース工程への引き継ぎ
 - #47 の時点では、テスト工程を止める重大不具合は残っていない。
-- 実動画で sidecar なしに文字認識する機能は、#72 の完了条件として扱う。
+- 実動画で sidecar なしに文字認識する機能は、Windows OCR baseline worker を起点に #72 の完了条件として扱う。
 - 配布物の成立条件は、#48 と #49 で Release build 出力前提か self-contained publish 再調査かを判断する。
 - 属性推定の範囲は #75 で初期リリース範囲と既知制約を切り分ける。

--- a/docs/09_Windows_OCRワーカー導入手順.md
+++ b/docs/09_Windows_OCRワーカー導入手順.md
@@ -1,0 +1,81 @@
+# Windows OCR ワーカー導入手順
+
+## 1. 文書情報
+- 対象 Issue: `#72`
+- 作成日: 2026-04-28
+- 対象工程: リリース
+- 記録者: Codex
+
+## 2. 目的
+`MOVIE_TELOP_OCR_WORKER` に指定できる実 OCR worker として、Windows 標準 OCR を利用する `MovieTelopTranscriber.Ocr.Windows` の使い方を定義する。
+
+## 3. 位置付け
+- `MovieTelopTranscriber.Ocr.Windows` は、初期リリースで sidecar なしの実画像 OCR を確認するための baseline worker とする。
+- OCR エンジンは Windows の `Windows.Media.Ocr` を利用する。
+- 追加の Python ランタイムや外部 OCR モデルは不要。
+- 認識品質は Windows OCR とインストール済み言語に依存するため、PaddleOCR などの専用 OCR より高精度とは限らない。
+
+## 4. ビルド
+```powershell
+dotnet build src\MovieTelopTranscriber.Ocr.Windows\MovieTelopTranscriber.Ocr.Windows.csproj -p:Platform=x64
+```
+
+出力例:
+
+```text
+src\MovieTelopTranscriber.Ocr.Windows\bin\x64\Debug\net10.0-windows10.0.26100.0\MovieTelopTranscriber.Ocr.Windows.exe
+```
+
+Release 用:
+
+```powershell
+dotnet build src\MovieTelopTranscriber.Ocr.Windows\MovieTelopTranscriber.Ocr.Windows.csproj -c Release -p:Platform=x64
+```
+
+## 5. アプリから利用する方法
+アプリ起動前に、OCR worker の実行ファイルを環境変数へ設定する。
+
+```powershell
+$env:MOVIE_TELOP_OCR_WORKER = "D:\Claude\Movie\movie-telop-transcriber\src\MovieTelopTranscriber.Ocr.Windows\bin\x64\Debug\net10.0-windows10.0.26100.0\MovieTelopTranscriber.Ocr.Windows.exe"
+$env:MOVIE_TELOP_OCR_ENGINE = "windows-ocr"
+
+Start-Process `
+  -FilePath "D:\Claude\Movie\movie-telop-transcriber\src\MovieTelopTranscriber.App\bin\x64\Release\net10.0-windows10.0.26100.0\MovieTelopTranscriber.App.exe" `
+  -WorkingDirectory "D:\Claude\Movie\movie-telop-transcriber\src\MovieTelopTranscriber.App\bin\x64\Release\net10.0-windows10.0.26100.0"
+```
+
+## 6. Worker 単体実行
+アプリ本体が生成した OCR request JSON と response JSON の出力先を指定して実行できる。
+
+```powershell
+dotnet run --project src\MovieTelopTranscriber.Ocr.Windows\MovieTelopTranscriber.Ocr.Windows.csproj -p:Platform=x64 -- `
+  work\runs\<run_id>\ocr\ocr-000011-00001000ms.request.json `
+  temp\windows-ocr-response.json
+```
+
+## 7. 設定
+### 7.1 OCR worker
+| 環境変数 | 内容 |
+| --- | --- |
+| `MOVIE_TELOP_OCR_WORKER` | `MovieTelopTranscriber.Ocr.Windows.exe` のパス |
+| `MOVIE_TELOP_OCR_ENGINE` | 画面とログに表示するエンジン名。推奨値は `windows-ocr` |
+
+### 7.2 小さい文字行の除外
+Windows OCR は、動画上部の時刻表示なども文字として検出する場合がある。`MovieTelopTranscriber.Ocr.Windows` は、既定で高さ 18px 未満の行を除外する。
+
+```powershell
+$env:MOVIE_TELOP_WINDOWS_OCR_MIN_HEIGHT = "18"
+```
+
+## 8. 既知制約
+- Windows OCR の利用可否と言語対応は、利用環境にインストールされている Windows OCR 言語に依存する。
+- 日本語テロップは検出できても、文字列が完全一致しない場合がある。
+- 現時点では Windows OCR の行単位検出結果をそのまま共通 OCR 契約へ変換する。
+- 信頼度は Windows OCR API から取得できないため `null` として出力する。
+- 小さい文字行除外はヒューリスティックであり、実動画によって調整が必要になる可能性がある。
+
+## 9. リリース工程への引き継ぎ
+- #72 では、Windows OCR worker を baseline として実動画 OCR を成立させる。
+- #48 では、worker exe と必要ランタイムを配布物へ含めるかを判断する。
+- #49 では、本手順を利用者向け導入手順へ統合する。
+- 精度が不足する場合は、PaddleOCR または Tesseract worker を追加候補として再評価する。

--- a/docs/test-results/2026-04-28_Windows_OCRワーカー検証.md
+++ b/docs/test-results/2026-04-28_Windows_OCRワーカー検証.md
@@ -1,0 +1,41 @@
+# Windows OCR ワーカー検証結果
+
+## 1. 文書情報
+- 対象 Issue: `#72`
+- 実施日: 2026-04-28
+- 対象: `MovieTelopTranscriber.Ocr.Windows`
+- 記録者: Codex
+
+## 2. 実施内容
+`sample_basic_telop.mp4` から抽出済みのフレームに対し、Windows OCR worker を単体実行した。
+
+```powershell
+dotnet build src\MovieTelopTranscriber.Ocr.Windows\MovieTelopTranscriber.Ocr.Windows.csproj -p:Platform=x64
+dotnet build src\MovieTelopTranscriber.Ocr.Windows\MovieTelopTranscriber.Ocr.Windows.csproj -c Release -p:Platform=x64
+
+dotnet run --project src\MovieTelopTranscriber.Ocr.Windows\MovieTelopTranscriber.Ocr.Windows.csproj -p:Platform=x64 -- `
+  work\runs\20260428_155035_e28c\ocr\ocr-000011-00001000ms.request.json `
+  temp\windows-ocr-response-1000-filtered.json
+
+src\MovieTelopTranscriber.Ocr.Windows\bin\x64\Release\net10.0-windows10.0.26100.0\MovieTelopTranscriber.Ocr.Windows.exe `
+  work\runs\20260428_155035_e28c\ocr\ocr-000011-00001000ms.request.json `
+  temp\windows-ocr-response-1000-release.json
+```
+
+## 3. 結果
+- worker の終了コードは `0`。
+- `status` は `success`。
+- 00:00:01.000 のフレームからテロップ行を 1 件検出した。
+- 小さい時刻表示行は、高さフィルターにより除外された。
+- 検出テキストは `サンプ丿レテロップ` であり、期待値 `サンプルテロップ` と完全一致はしなかった。
+- Debug / Release の worker 単体実行で同等の response JSON が生成された。
+
+## 4. 判断
+- sidecar なしの画像に対し、実 OCR worker 経由で文字行を検出する経路は成立した。
+- Windows OCR baseline は追加ランタイムが少なく導入しやすい一方、日本語テロップの認識精度には制約が残る。
+- 初期リリースで Windows OCR を採用する場合は、精度制約をリリースノートと導入手順へ明記する必要がある。
+
+## 5. 後続確認
+- アプリ本体を `MOVIE_TELOP_OCR_WORKER` 指定で起動し、抽出から出力まで Windows OCR worker で通ること。
+- 実動画で代表的なテロップ文字が検出されること。
+- Windows OCR の精度が不足する場合、PaddleOCR または Tesseract worker を再評価すること。

--- a/src/MovieTelopTranscriber.Ocr.Windows/MovieTelopTranscriber.Ocr.Windows.csproj
+++ b/src/MovieTelopTranscriber.Ocr.Windows/MovieTelopTranscriber.Ocr.Windows.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <RootNamespace>MovieTelopTranscriber.Ocr.Windows</RootNamespace>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/MovieTelopTranscriber.Ocr.Windows/Program.cs
+++ b/src/MovieTelopTranscriber.Ocr.Windows/Program.cs
@@ -1,0 +1,306 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Windows.Globalization;
+using Windows.Graphics.Imaging;
+using Windows.Media.Ocr;
+using Windows.Storage;
+
+return await WindowsOcrWorker.RunAsync(args);
+
+internal static class WindowsOcrWorker
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true
+    };
+
+    public static async Task<int> RunAsync(string[] args)
+    {
+        if (args.Length != 2)
+        {
+            Console.Error.WriteLine("usage: MovieTelopTranscriber.Ocr.Windows <request.json> <response.json>");
+            return 2;
+        }
+
+        var requestPath = args[0];
+        var responsePath = args[1];
+
+        OcrWorkerRequest? request = null;
+        try
+        {
+            await using var requestStream = File.OpenRead(requestPath);
+            request = await JsonSerializer.DeserializeAsync<OcrWorkerRequest>(requestStream, JsonOptions);
+            if (request is null)
+            {
+                Console.Error.WriteLine("request json was empty.");
+                return 2;
+            }
+
+            var response = await RecognizeAsync(request);
+            await WriteResponseAsync(responsePath, response);
+            return 0;
+        }
+        catch (Exception ex) when (request is not null)
+        {
+            var response = CreateErrorResponse(
+                request,
+                "WINDOWS_OCR_FAILED",
+                "Windows OCR worker failed.",
+                ex.Message,
+                true);
+            await WriteResponseAsync(responsePath, response);
+            return 0;
+        }
+        catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return 2;
+        }
+    }
+
+    private static async Task<OcrWorkerResponse> RecognizeAsync(OcrWorkerRequest request)
+    {
+        if (!File.Exists(request.ImagePath))
+        {
+            return CreateErrorResponse(
+                request,
+                "OCR_IMAGE_NOT_FOUND",
+                "OCR target image was not found.",
+                request.ImagePath,
+                true);
+        }
+
+        var engine = CreateEngine(request.LanguageHint);
+        if (engine is null)
+        {
+            return CreateErrorResponse(
+                request,
+                "OCR_ENGINE_NOT_AVAILABLE",
+                "Windows OCR engine is not available for the requested language.",
+                $"language_hint={request.LanguageHint}",
+                true);
+        }
+
+        using var image = await LoadBitmapAsync(request.ImagePath);
+        var result = await engine.RecognizeAsync(image.Bitmap);
+        var detections = result.Lines
+            .Select((line, index) => CreateDetection(request, line, index, image.Scale))
+            .Where(detection => !string.IsNullOrWhiteSpace(detection.Text))
+            .Where(detection => EstimateHeight(detection.BoundingBox) >= GetMinimumLineHeight())
+            .ToArray();
+
+        return new OcrWorkerResponse(
+            request.RequestId,
+            "success",
+            request.FrameIndex,
+            request.TimestampMs,
+            detections,
+            null);
+    }
+
+    private static OcrEngine? CreateEngine(string languageHint)
+    {
+        foreach (var languageTag in GetLanguageCandidates(languageHint))
+        {
+            try
+            {
+                var engine = OcrEngine.TryCreateFromLanguage(new Language(languageTag));
+                if (engine is not null)
+                {
+                    return engine;
+                }
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+
+        return OcrEngine.TryCreateFromUserProfileLanguages();
+    }
+
+    private static IEnumerable<string> GetLanguageCandidates(string languageHint)
+    {
+        var normalized = languageHint.Trim().ToLowerInvariant();
+        if (normalized.StartsWith("ja", StringComparison.Ordinal))
+        {
+            yield return "ja";
+            yield break;
+        }
+
+        if (normalized.StartsWith("en", StringComparison.Ordinal))
+        {
+            yield return "en";
+            yield break;
+        }
+
+        if (normalized.StartsWith("zh", StringComparison.Ordinal))
+        {
+            yield return "zh-Hans";
+            yield return "zh-Hant";
+            yield return "zh-CN";
+            yield return "zh-TW";
+            yield break;
+        }
+
+        if (normalized.StartsWith("ko", StringComparison.Ordinal))
+        {
+            yield return "ko";
+            yield break;
+        }
+
+        if (!string.IsNullOrWhiteSpace(languageHint))
+        {
+            yield return languageHint;
+        }
+    }
+
+    private static async Task<OcrInputImage> LoadBitmapAsync(string path)
+    {
+        var file = await StorageFile.GetFileFromPathAsync(Path.GetFullPath(path));
+        using var stream = await file.OpenReadAsync();
+        var decoder = await BitmapDecoder.CreateAsync(stream);
+        var scale = Math.Min(2d, (double)OcrEngine.MaxImageDimension / Math.Max(decoder.PixelWidth, decoder.PixelHeight));
+        var transform = new BitmapTransform
+        {
+            ScaledWidth = Math.Max(1u, (uint)Math.Round(decoder.PixelWidth * scale)),
+            ScaledHeight = Math.Max(1u, (uint)Math.Round(decoder.PixelHeight * scale))
+        };
+
+        var bitmap = await decoder.GetSoftwareBitmapAsync(
+            BitmapPixelFormat.Bgra8,
+            BitmapAlphaMode.Premultiplied,
+            transform,
+            ExifOrientationMode.RespectExifOrientation,
+            ColorManagementMode.ColorManageToSRgb);
+
+        return new OcrInputImage(bitmap, scale);
+    }
+
+    private static OcrDetectionRecord CreateDetection(OcrWorkerRequest request, OcrLine line, int index, double scale)
+    {
+        var bounds = line.Words
+            .Select(word => word.BoundingRect)
+            .ToArray();
+        var boundingBox = bounds.Length == 0
+            ? Array.Empty<OcrBoundingPoint>()
+            : CreateBoundingBox(
+                bounds.Min(rect => rect.X) / scale,
+                bounds.Min(rect => rect.Y) / scale,
+                bounds.Max(rect => rect.X + rect.Width) / scale,
+                bounds.Max(rect => rect.Y + rect.Height) / scale);
+
+        return new OcrDetectionRecord(
+            $"winocr-{request.FrameIndex:D6}-{request.TimestampMs:D8}ms-{index + 1:D2}",
+            NormalizeText(line.Text),
+            null,
+            boundingBox);
+    }
+
+    private static double GetMinimumLineHeight()
+    {
+        var value = Environment.GetEnvironmentVariable("MOVIE_TELOP_WINDOWS_OCR_MIN_HEIGHT");
+        return double.TryParse(value, out var minHeight) ? minHeight : 18d;
+    }
+
+    private static double EstimateHeight(IReadOnlyList<OcrBoundingPoint> boundingBox)
+    {
+        if (boundingBox.Count == 0)
+        {
+            return 0d;
+        }
+
+        return boundingBox.Max(point => point.Y) - boundingBox.Min(point => point.Y);
+    }
+
+    private static string NormalizeText(string text)
+    {
+        return ContainsJapaneseOrCjk(text)
+            ? string.Concat(text.Where(character => !char.IsWhiteSpace(character)))
+            : text.Trim();
+    }
+
+    private static bool ContainsJapaneseOrCjk(string text)
+    {
+        return text.Any(character =>
+            character is >= '\u3040' and <= '\u30ff'
+            || character is >= '\u3400' and <= '\u9fff'
+            || character is >= '\uf900' and <= '\ufaff');
+    }
+
+    private static OcrBoundingPoint[] CreateBoundingBox(double left, double top, double right, double bottom)
+    {
+        return
+        [
+            new OcrBoundingPoint(left, top),
+            new OcrBoundingPoint(right, top),
+            new OcrBoundingPoint(right, bottom),
+            new OcrBoundingPoint(left, bottom)
+        ];
+    }
+
+    private static async Task WriteResponseAsync(string responsePath, OcrWorkerResponse response)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(responsePath))!);
+        await using var responseStream = File.Create(responsePath);
+        await JsonSerializer.SerializeAsync(responseStream, response, JsonOptions);
+    }
+
+    private static OcrWorkerResponse CreateErrorResponse(
+        OcrWorkerRequest request,
+        string code,
+        string message,
+        string? details,
+        bool recoverable)
+    {
+        return new OcrWorkerResponse(
+            request.RequestId,
+            "error",
+            request.FrameIndex,
+            request.TimestampMs,
+            Array.Empty<OcrDetectionRecord>(),
+            new ProcessingError(code, message, details, recoverable));
+    }
+}
+
+internal sealed record OcrWorkerRequest(
+    string RequestId,
+    int FrameIndex,
+    long TimestampMs,
+    string ImagePath,
+    string LanguageHint,
+    string Engine);
+
+internal sealed record OcrWorkerResponse(
+    string RequestId,
+    string Status,
+    int FrameIndex,
+    long TimestampMs,
+    IReadOnlyList<OcrDetectionRecord> Detections,
+    ProcessingError? Error);
+
+internal sealed record OcrDetectionRecord(
+    string DetectionId,
+    string Text,
+    double? Confidence,
+    IReadOnlyList<OcrBoundingPoint> BoundingBox);
+
+internal sealed record OcrBoundingPoint(double X, double Y);
+
+internal sealed record ProcessingError(
+    string Code,
+    string Message,
+    string? Details,
+    bool Recoverable);
+
+internal sealed class OcrInputImage(SoftwareBitmap bitmap, double scale) : IDisposable
+{
+    public SoftwareBitmap Bitmap { get; } = bitmap;
+
+    public double Scale { get; } = scale;
+
+    public void Dispose()
+    {
+        Bitmap.Dispose();
+    }
+}

--- a/src/MovieTelopTranscriber.sln
+++ b/src/MovieTelopTranscriber.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MovieTelopTranscriber.App", "MovieTelopTranscriber.App\MovieTelopTranscriber.App.csproj", "{906C4468-BB8B-499C-9D56-100F6FE6921F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MovieTelopTranscriber.Ocr.Windows", "MovieTelopTranscriber.Ocr.Windows\MovieTelopTranscriber.Ocr.Windows.csproj", "{E8489C43-F434-4720-84D6-985198ED6B8A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,18 @@ Global
 		{906C4468-BB8B-499C-9D56-100F6FE6921F}.Release|x64.Build.0 = Release|x64
 		{906C4468-BB8B-499C-9D56-100F6FE6921F}.Release|x86.ActiveCfg = Release|x64
 		{906C4468-BB8B-499C-9D56-100F6FE6921F}.Release|x86.Build.0 = Release|x64
+		{E8489C43-F434-4720-84D6-985198ED6B8A}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{E8489C43-F434-4720-84D6-985198ED6B8A}.Debug|Any CPU.Build.0 = Debug|x64
+		{E8489C43-F434-4720-84D6-985198ED6B8A}.Debug|x64.ActiveCfg = Debug|x64
+		{E8489C43-F434-4720-84D6-985198ED6B8A}.Debug|x64.Build.0 = Debug|x64
+		{E8489C43-F434-4720-84D6-985198ED6B8A}.Debug|x86.ActiveCfg = Debug|x64
+		{E8489C43-F434-4720-84D6-985198ED6B8A}.Debug|x86.Build.0 = Debug|x64
+		{E8489C43-F434-4720-84D6-985198ED6B8A}.Release|Any CPU.ActiveCfg = Release|x64
+		{E8489C43-F434-4720-84D6-985198ED6B8A}.Release|Any CPU.Build.0 = Release|x64
+		{E8489C43-F434-4720-84D6-985198ED6B8A}.Release|x64.ActiveCfg = Release|x64
+		{E8489C43-F434-4720-84D6-985198ED6B8A}.Release|x64.Build.0 = Release|x64
+		{E8489C43-F434-4720-84D6-985198ED6B8A}.Release|x86.ActiveCfg = Release|x64
+		{E8489C43-F434-4720-84D6-985198ED6B8A}.Release|x86.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/movie-telop-transcriber.slnx
+++ b/src/movie-telop-transcriber.slnx
@@ -1,3 +1,4 @@
 <Solution>
   <Project Path="MovieTelopTranscriber.App/MovieTelopTranscriber.App.csproj" />
+  <Project Path="MovieTelopTranscriber.Ocr.Windows/MovieTelopTranscriber.Ocr.Windows.csproj" />
 </Solution>


### PR DESCRIPTION
## 概要
- `MovieTelopTranscriber.Ocr.Windows` console worker を追加しました。
- 既存の `MOVIE_TELOP_OCR_WORKER request.json response.json` 契約に合わせ、Windows 標準 OCR の行単位結果を共通 OCR response JSON へ変換します。
- 小さい文字行の除外と、日本語/CJKテキストの空白正規化を追加しました。
- Windows OCR worker の導入手順と単体検証結果を docs に追加しました。

## 確認
- `dotnet build src\MovieTelopTranscriber.sln -p:Platform=x64`
- `dotnet build src\MovieTelopTranscriber.Ocr.Windows\MovieTelopTranscriber.Ocr.Windows.csproj -c Release -p:Platform=x64`
- Release worker exe 単体実行で `status=success` の response JSON を生成
- `git diff --check`
- `rg --line-number "効く" README.md docs src -S` で該当なし

## 残り
- アプリ本体を `MOVIE_TELOP_OCR_WORKER` 指定で起動し、抽出から出力まで Windows OCR worker で通ることを手動確認する必要があります。
- サンプルでは文字行検出はできていますが、日本語テキストは完全一致していません。必要に応じて PaddleOCR / Tesseract の再評価が必要です。

Refs #72
Refs #48
Refs #49