### PR TITLE
docs: OCRエンジン比較検討を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - 外部 OCR ワーカーは `MOVIE_TELOP_OCR_WORKER` 環境変数で指定する。
 - 未指定時はフレーム同名の `.ocr.json` サイドカーを読み込み、サイドカーがない場合は空検出として処理を継続する。
 - Windows 標準 OCR を使う baseline worker は `src/MovieTelopTranscriber.Ocr.Windows/` に実装済み。
+- Windows OCR の手動検証では日本語テロップの認識精度が不足したため、#72 では PaddleOCR PP-OCRv5 worker を第一候補として追加検討中。
 - 中間成果物は `work/runs/<run_id>/frames`、`ocr`、`attributes` に分けて保存する。
 - 最終成果物は `work/runs/<run_id>/output/segments.json`、`segments.csv`、`frames.csv` として保存する。
 - 実行ログは `work/runs/<run_id>/logs/run.log` と `summary.json` として保存する。
@@ -74,4 +75,5 @@
 - 現行の OCR 精度検証では、外部 OCR ワーカーまたは動画ごとの `.ocr.json` サイドカーがない任意動画は空検出になる。サンプル sidecar では文字列とセグメント時刻が期待値と一致する一方、フォント名、色、背景色、精密な種別は未推定値として扱う。
 - 既知不具合と制約は `docs/08_既知不具合と制約一覧.md` に整理済み。
 - テスト工程完了レビューは `docs/test-results/2026-04-28_テスト工程完了レビュー.md` に記録済み。
+- OCR エンジン比較検討は `docs/test-results/2026-04-28_OCRエンジン比較検討.md` に記録済み。
 - リリース工程では、実 OCR ワーカー、配布構成、導入手順、リリースノート、GitHub Release を順に確定する。

--- a/docs/08_既知不具合と制約一覧.md
+++ b/docs/08_既知不具合と制約一覧.md
@@ -23,7 +23,7 @@
 ## 5. 既知制約
 | ID | 内容 | 影響 | 回避策 | 後続 Issue | リリース判断 |
 | --- | --- | --- | --- | --- | --- |
-| C-001 | `MOVIE_TELOP_OCR_WORKER` 未設定時は `json-sidecar` で動作し、抽出フレームと同名の `.ocr.json` がない場合は空検出になる。Windows OCR baseline worker は追加済みだが、精度と配布形態はリリース工程で確定する。 | worker 未設定の任意実動画では文字認識は成立しない。Windows OCR でも日本語テロップは完全一致しない場合がある。 | サンプルでは `materialize_sidecars.py` で sidecar を生成し、`OCR 再実行` を実施する。実 OCR 確認では `MovieTelopTranscriber.Ocr.Windows` を `MOVIE_TELOP_OCR_WORKER` に指定する。 | `#72` | 実動画 OCR を初期リリース要件に含める場合、#72 完了が必要。 |
+| C-001 | `MOVIE_TELOP_OCR_WORKER` 未設定時は `json-sidecar` で動作し、抽出フレームと同名の `.ocr.json` がない場合は空検出になる。Windows OCR baseline worker は追加済みだが、日本語テロップの認識精度が不足したため PaddleOCR PP-OCRv5 worker を第一候補として再評価している。 | worker 未設定の任意実動画では文字認識は成立しない。Windows OCR でも日本語テロップは完全一致しない場合がある。PaddleOCR 採用時は Python ランタイム、モデル、初回ダウンロードまたは同梱物の扱いが配布条件に影響する。 | サンプルでは `materialize_sidecars.py` で sidecar を生成し、`OCR 再実行` を実施する。実 OCR 確認では Windows OCR baseline または PaddleOCR worker を `MOVIE_TELOP_OCR_WORKER` に指定する。 | `#72`、`#48`、`#49` | 実動画 OCR を初期リリース要件に含める場合、#72 完了が必要。PaddleOCR 採用時の配布条件は #48 / #49 で確定する。 |
 | C-002 | `materialize_sidecars.py` は `sample_basic_telop.mp4` 専用であり、任意動画の `frames/` に実行するとサンプル動画用 OCR 結果が書き込まれる。 | 任意動画の検証結果を誤って解釈する可能性がある。 | `test-data/basic_telop/README.md` の注意書きに従い、サンプル動画以外には使わない。 | 追加 Issue なし | 文書化済みの検証補助制約として扱う。 |
 | C-003 | `font_family`、`text_color`、`stroke_color`、`background_color`、精密な `text_type` は現行実装では未推定値として扱う。 | 出力スキーマには項目が存在するが、実用的な見た目分類は未成立。 | 現行リリースでは未推定値として扱い、必要に応じて後続の画像解析で補完する。 | `#75` | 初期リリース範囲と既知制約のどちらに入れるか #75 で確定する。 |
 | C-004 | `font_size` は表示フォントサイズではなく OCR 矩形の高さ相当値として推定している。 | 実フォントサイズとして扱うと解釈を誤る可能性がある。 | 導入手順、リリースノート、出力仕様で「矩形高さ相当」として説明する。 | `#75` | #75 で表記と扱いを確定する。 |
@@ -38,6 +38,6 @@
 
 ## 7. リリース工程への引き継ぎ
 - #47 の時点では、テスト工程を止める重大不具合は残っていない。
-- 実動画で sidecar なしに文字認識する機能は、Windows OCR baseline worker を起点に #72 の完了条件として扱う。
+- 実動画で sidecar なしに文字認識する機能は、Windows OCR baseline worker の結果を踏まえ、PaddleOCR PP-OCRv5 worker を第一候補として #72 の完了条件に扱う。
 - 配布物の成立条件は、#48 と #49 で Release build 出力前提か self-contained publish 再調査かを判断する。
 - 属性推定の範囲は #75 で初期リリース範囲と既知制約を切り分ける。

--- a/docs/09_Windows_OCRワーカー導入手順.md
+++ b/docs/09_Windows_OCRワーカー導入手順.md
@@ -14,6 +14,7 @@
 - OCR エンジンは Windows の `Windows.Media.Ocr` を利用する。
 - 追加の Python ランタイムや外部 OCR モデルは不要。
 - 認識品質は Windows OCR とインストール済み言語に依存するため、PaddleOCR などの専用 OCR より高精度とは限らない。
+- 2026-04-28 の手動検証では日本語テロップの認識精度が不足したため、#72 の第一候補は PaddleOCR PP-OCRv5 worker へ切り替えて検討する。
 
 ## 4. ビルド
 ```powershell
@@ -75,7 +76,7 @@ $env:MOVIE_TELOP_WINDOWS_OCR_MIN_HEIGHT = "18"
 - 小さい文字行除外はヒューリスティックであり、実動画によって調整が必要になる可能性がある。
 
 ## 9. リリース工程への引き継ぎ
-- #72 では、Windows OCR worker を baseline として実動画 OCR を成立させる。
+- #72 では、Windows OCR worker を baseline として残しつつ、PaddleOCR PP-OCRv5 worker を第一候補として実動画 OCR を成立させる。
 - #48 では、worker exe と必要ランタイムを配布物へ含めるかを判断する。
 - #49 では、本手順を利用者向け導入手順へ統合する。
-- 精度が不足する場合は、PaddleOCR または Tesseract worker を追加候補として再評価する。
+- PaddleOCR 採用後に配布形態が重くなりすぎる場合は、Tesseract または ONNX Runtime 利用を代替候補として再評価する。

--- a/docs/test-results/2026-04-28_OCRエンジン比較検討.md
+++ b/docs/test-results/2026-04-28_OCRエンジン比較検討.md
@@ -1,0 +1,80 @@
+# OCR エンジン比較検討
+
+## 1. 文書情報
+- 対象 Issue: `#72`
+- 作成日: 2026-04-28
+- 対象工程: リリース
+- 記録者: Codex
+
+## 2. 目的
+Windows OCR baseline worker の手動検証で日本語テロップの認識精度が不足したため、PaddleOCR、Tesseract、ONNX Runtime 利用を比較し、#72 の次の実装方針を決める。
+
+## 3. 比較対象
+| 候補 | 評価 | 理由 |
+| --- | --- | --- |
+| Windows OCR | 継続 fallback | 追加ランタイム不要で導入しやすいが、日本語テロップでは欠字や誤認識が発生した。信頼度も取得できない。 |
+| PaddleOCR PP-OCRv5 | 第一候補 | 実フレーム PoC で日本語テロップを高スコアで認識した。日本語を含む多言語 OCR と Windows 対応が公式に示されている。 |
+| Tesseract 5.x | fallback 候補 | LSTM ベースで日本語/英語/中国語/韓国語の traineddata を利用できる。軽量だが、動画テロップの装飾、縁取り、背景変化に対する精度は追加検証が必要。 |
+| ONNX Runtime | 配布最適化候補 | 単独の OCR エンジンではなく、採用モデルを .NET / C# から推論する配布方式として扱う。まず PaddleOCR で精度基準を満たし、その後 ONNX 化を検討する。 |
+
+## 4. ローカル PoC
+### 4.1 環境
+- 評価用 Python: `Python 3.10.6`
+- 評価環境: `temp/ocr-eval/.venv`
+- PaddlePaddle: `3.2.0` CPU
+- PaddleOCR: `3.5.0`
+- モデル: `PP-OCRv5_server_det`、`PP-OCRv5_server_rec`
+- 入力 run: `work/runs/20260428_180845_b571`
+- 対象動画: `test-data/basic_telop/botirist.mp4`
+
+### 4.2 検証コマンド
+```powershell
+python -m venv temp\ocr-eval\.venv
+temp\ocr-eval\.venv\Scripts\python.exe -m pip install --upgrade pip
+temp\ocr-eval\.venv\Scripts\python.exe -m pip install paddlepaddle==3.2.0 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
+temp\ocr-eval\.venv\Scripts\python.exe -m pip install paddleocr
+```
+
+```powershell
+temp\ocr-eval\.venv\Scripts\python.exe -m paddleocr ocr `
+  -i work\runs\20260428_180845_b571\frames\frame_000031_00001000ms.png `
+  --save_path temp\ocr-eval\paddle-frame-000031 `
+  --lang japan `
+  --ocr_version PP-OCRv5 `
+  --device cpu `
+  --use_doc_orientation_classify False `
+  --use_doc_unwarping False `
+  --use_textline_orientation False
+```
+
+### 4.3 結果
+| フレーム | Windows OCR | PaddleOCR PP-OCRv5 |
+| --- | --- | --- |
+| `frame_000031_00001000ms.png` | `語で脅してくる奴`、`単語知らないママ` | `隠語で脅してくる奴`、`VS`、`単語知らないママ` |
+
+PaddleOCR の同フレーム認識スコア:
+
+| テキスト | スコア |
+| --- | --- |
+| `隠語で脅してくる奴` | `0.999713` |
+| `VS` | `0.851525` |
+| `単語知らないママ` | `0.998826` |
+
+先頭 5 フレームを同一 `PaddleOCR` インスタンスで処理した CPU 時間は約 `1.9` から `4.3` 秒/フレームだった。初期リリースでは精度を優先し、速度最適化は後続で扱う。
+
+## 5. 判断
+#72 の実 OCR worker は PaddleOCR PP-OCRv5 を第一候補に切り替える。Windows OCR worker は軽量 fallback として残す。Tesseract は PaddleOCR 導入が配布面で成立しない場合の代替候補とし、ONNX Runtime は PaddleOCR 採用後の配布最適化候補として扱う。
+
+## 6. 次の実装方針
+- `MOVIE_TELOP_OCR_WORKER` から直接呼べる PaddleOCR worker を追加する。
+- 初期実装では Python worker と .NET proxy executable の組み合わせを許容し、アプリ本体の JSON I/O 契約は維持する。
+- worker は `request.json` / `response.json` の既存契約を読み書きし、`rec_texts`、`rec_scores`、`rec_polys` を `OcrDetectionRecord` へ変換する。
+- モデルの初回ダウンロードをリリース手順で明記するか、配布物へモデルを含めるかは #48 / #49 で確定する。
+- 代表動画で文字検出、文字列出力、セグメント生成まで再検証する。
+
+## 7. 参照
+- PaddleOCR PP-OCRv5: https://www.paddleocr.ai/main/en/version3.x/algorithm/PP-OCRv5/PP-OCRv5.html
+- PaddleOCR installation: https://www.paddleocr.ai/v3.3.0/en/version3.x/installation.html
+- PaddleOCR ONNX model conversion: https://www.paddleocr.ai/latest/en/version3.x/deployment/obtaining_onnx_models.html
+- Tesseract data files: https://tesseract-ocr.github.io/tessdoc/Data-Files.html
+- ONNX Runtime C# API: https://onnxruntime.ai/docs/get-started/with-csharp.html


### PR DESCRIPTION
## 概要
- Windows OCR の手動検証結果を踏まえ、PaddleOCR / Tesseract / ONNX Runtime の比較検討を追加
- PaddleOCR PP-OCRv5 を #72 の第一候補、Windows OCR を fallback として整理
- README、既知制約、Windows OCR 導入手順へ現在方針を反映

## 検証
- `git diff --check`
- PaddleOCR PP-OCRv5 CPU PoC: `frame_000031_00001000ms.png` で `隠語で脅してくる奴` / `VS` / `単語知らないママ` を検出