### PR TITLE
[リリース] #51 配布物検証記録を更新する

### DIFF
--- a/docs/11_配布構成と同梱物.md
+++ b/docs/11_配布構成と同梱物.md
@@ -120,7 +120,7 @@ movie-telop-transcriber-win-x64-v<version>/
 
 主なサイズ要因は `win-x64/`、`runtimes/`、Windows App SDK / WinUI 関連 DLL、ONNX Runtime、DirectML、OpenCVSharp である。#51 の zip 作成時に、最終的な圧縮後サイズを release asset の検査結果として記録する。
 
-#51 の `v0.1.0` 配布物作成では、`movie-telop-transcriber-win-x64-v0.1.0.zip` の圧縮後サイズは 246,779,347 bytes、展開後サイズは 634,670,703 bytes、展開後ファイル数は 1,096 件だった。
+#51 の最終的な zip サイズ、展開後サイズ、checksum は、配布物作成後の検証結果と GitHub Release の記録で扱う。
 
 ## 9. 配布制約と後続判断
 | ID | 制約 | 初期リリースでの扱い | 後続判断 |

--- a/docs/test-results/2026-04-29_issue51_release_package.md
+++ b/docs/test-results/2026-04-29_issue51_release_package.md
@@ -46,6 +46,6 @@ Get-FileHash -LiteralPath dist\movie-telop-transcriber-win-x64-v0.1.0.zip -Algor
 | zip | `dist/movie-telop-transcriber-win-x64-v0.1.0.zip` |
 | checksum | `dist/movie-telop-transcriber-win-x64-v0.1.0.zip.sha256` |
 | 展開後ファイル数 | 1,096 |
-| 展開後サイズ | 634,670,703 bytes |
-| zip サイズ | 246,779,347 bytes |
-| SHA-256 | `021800d51d3af388862c5ca0a7ed2349781b05eeac0e2bac121554f44e43b372` |
+| 展開後サイズ | 634,670,867 bytes |
+| zip サイズ | 246,779,389 bytes |
+| SHA-256 | `98eb0692ddc907b65cec727c81a2e4c5bab2da454e91266fa39a40d25f8be18a` |


### PR DESCRIPTION
## 概要
- zip 内に含める `docs/11_配布構成と同梱物.md` から生成後サイズの固定値を外し、最終値は検証結果と GitHub Release 記録で扱う形にしました。
- `docs/test-results/2026-04-29_issue51_release_package.md` を、再生成後の最終 package 値へ更新しました。

## 検証
- `tools\release\New-ReleasePackage.ps1 -Version 0.1.0`
- zip 展開後に必須ファイルを確認
- `test-data/basic_telop/botirist.mp4` が含まれないことを確認
- `*.pdb` が含まれないことを確認
- `$term = [string]([char]0x52b9) + [string]([char]0x304f); rg -n $term README.md docs tools`
- `git diff --check`

## 最終配布物情報
- zip: `dist/movie-telop-transcriber-win-x64-v0.1.0.zip`
- checksum: `dist/movie-telop-transcriber-win-x64-v0.1.0.zip.sha256`
- 展開後ファイル数: 1,096
- 展開後サイズ: 634,670,867 bytes
- zip サイズ: 246,779,389 bytes
- SHA-256: `98eb0692ddc907b65cec727c81a2e4c5bab2da454e91266fa39a40d25f8be18a`

#51 の公開前補正です。Issue は PR #109 で closed 済みのため、この PR では自動 close 指定は行いません。