### PR TITLE
[リリース] #51 配布物タイムスタンプを固定する

### DIFF
--- a/docs/test-results/2026-04-29_issue51_release_package.md
+++ b/docs/test-results/2026-04-29_issue51_release_package.md
@@ -47,5 +47,5 @@ Get-FileHash -LiteralPath dist\movie-telop-transcriber-win-x64-v0.1.0.zip -Algor
 | checksum | `dist/movie-telop-transcriber-win-x64-v0.1.0.zip.sha256` |
 | 展開後ファイル数 | 1,096 |
 | 展開後サイズ | 634,670,868 bytes |
-| zip サイズ | 246,779,387 bytes |
-| SHA-256 | `9c951976e0f08e74ca96b2ece4999c98d5da2de26bda3091d06fc9c5d29b39a8` |
+| zip サイズ | 246,779,386 bytes |
+| SHA-256 | `f1d894e182ce8d7487d34a3cb5b87274d0708e41588b7bba83428e5255b97128` |

--- a/tools/release/New-ReleasePackage.ps1
+++ b/tools/release/New-ReleasePackage.ps1
@@ -27,6 +27,7 @@ $stagingRoot = Join-Path $OutputRoot "staging"
 $packageRoot = Join-Path $stagingRoot $packageName
 $zipPath = Join-Path $OutputRoot "$packageName.zip"
 $checksumPath = "$zipPath.sha256"
+$packageTimestampUtc = [DateTimeOffset]::Parse("2026-04-29T00:00:00Z").UtcDateTime
 
 function Copy-RepoFile {
     param(
@@ -135,6 +136,13 @@ foreach ($relativePath in $requiredPackageFiles) {
 }
 Test-PackageFile -RelativePattern "docs\12_*.md"
 Test-PackageFile -RelativePattern "docs\13_*.md"
+
+$packageItems = @((Get-Item -LiteralPath $packageRoot)) + @(Get-ChildItem -LiteralPath $packageRoot -Recurse -Force)
+$packageItems | ForEach-Object {
+    $_.CreationTimeUtc = $packageTimestampUtc
+    $_.LastAccessTimeUtc = $packageTimestampUtc
+    $_.LastWriteTimeUtc = $packageTimestampUtc
+}
 
 Compress-Archive -LiteralPath $packageRoot -DestinationPath $zipPath -CompressionLevel Optimal
 $hash = Get-FileHash -LiteralPath $zipPath -Algorithm SHA256


### PR DESCRIPTION
## 概要
- 配布物作成時に staging 配下のファイル timestamp を固定し、zip 内メタデータの不要な揺れを抑えるようにしました。
- 公開対象として検証済みの zip サイズと SHA-256 を検証結果へ反映しました。

## 検証
- `tools\release\New-ReleasePackage.ps1 -Version 0.1.0`
- `tools\release\New-ReleasePackage.ps1 -Version 0.1.0 -SkipBuild`
- zip 展開後に必須ファイルを確認
- `test-data/basic_telop/botirist.mp4` が含まれないことを確認
- `*.pdb` が含まれないことを確認
- `$term = [string]([char]0x52b9) + [string]([char]0x304f); rg -n $term README.md docs tools`
- `git diff --check`

## 公開対象 asset
- zip: `dist/movie-telop-transcriber-win-x64-v0.1.0.zip`
- checksum: `dist/movie-telop-transcriber-win-x64-v0.1.0.zip.sha256`
- 展開後ファイル数: 1,096
- 展開後サイズ: 634,670,868 bytes
- zip サイズ: 246,779,386 bytes
- SHA-256: `f1d894e182ce8d7487d34a3cb5b87274d0708e41588b7bba83428e5255b97128`