### PR TITLE
[リリース] #18 リリース工程完了レビューを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@
 - `tools/release/`: 配布物作成スクリプト
 
 ## 現在工程
-1. リリース
-2. リリース工程の親 Issue: `#18`
+1. 初期リリース `v0.1.0` 公開済み
+2. リリース工程の親 Issue `#18` は完了整理対象
 3. テスト工程の親 Issue `#21` と個別 Issue `#42` から `#47` は完了済み
-4. 現在の個別 Issue: `#51` GitHub リリースと配布物公開を行う
+4. リリース工程の個別 Issue `#48`、`#49`、`#50`、`#51` は完了済み
+5. 現在残っている主な open Issue は `#98` タイムライン結合・分割 UI とプレビュー同期のリリース後対応
 
 ## 実装メモ
 - 動画メタデータ読込とフレーム抽出を実装済み。
@@ -129,4 +130,5 @@
 - 導入手順は `docs/12_導入手順書.md` に整理済み。Release build 出力、.NET 10 Desktop Runtime、PaddleOCR Python 環境、モデル事前配置、初回確認、導入失敗時の確認項目を扱う。
 - 初期リリースの対象バージョンは `v0.1.0` とする。`segments.json` の `run_metadata.application_version` はアセンブリの informational version を使い、`0.1.0` として出力する。
 - リリースノートは `docs/13_リリースノート.md` に整理済み。GitHub Release 本文と配布物公開で参照する。
-- リリース工程では、GitHub Release と配布物公開を次に確定する。
+- GitHub Release `v0.1.0` は公開済み。配布 asset は `movie-telop-transcriber-win-x64-v0.1.0.zip` と `.zip.sha256`。
+- リリース後の次の主タスクは `#98` タイムライン結合・分割 UI とプレビュー同期の再設計。

--- a/docs/02_開発工程.md
+++ b/docs/02_開発工程.md
@@ -121,7 +121,7 @@
 - 工程完了レビューとして `AGENTS.md`、`SKILL.md`、`README.md`、関連 `docs/` の整合確認が終わっていること。
 
 ## 4. 直近の進め方
-- 現在工程: リリース
+- 現在工程: 初期リリース `v0.1.0` 公開済み。リリース後改善へ移行する。
 - 前工程: テスト
 - 実装工程の親 Issue `#19` と個別 Issue `#31`、`#33`、`#39`、`#40`、`#41` は完了済み。
 - テスト工程の親 Issue `#21` は完了済み。
@@ -148,7 +148,10 @@
 - `#48` で `docs/11_配布構成と同梱物.md` を作成し、初期リリースの配布構成、同梱物、非同梱物、配布サイズ、制約を整理済み。
 - `#49` で `docs/12_導入手順書.md` を作成し、Release build 出力、.NET 10 Desktop Runtime、PaddleOCR Python 環境、モデル事前配置、初回確認、導入失敗時の確認項目を整理済み。
 - `#50` で `docs/13_リリースノート.md` を作成し、`v0.1.0` の提供範囲、導入前提、既知制約、今後の予定を整理済み。
-- 次に着手する個別 Issue は `#51` GitHub リリースと配布物公開。
+- `#51` で `tools/release/New-ReleasePackage.ps1`、配布 zip、checksum、GitHub Release `v0.1.0` を整備済み。
+- GitHub Release: `https://github.com/Sunmax0731/movie-telop-transcriber/releases/tag/v0.1.0`
+- リリース工程の親 Issue `#18` は、工程完了レビュー後に close する。
+- 次に着手する主な open Issue は `#98` タイムライン結合・分割 UI とプレビュー同期の再設計。
 
 ## 5. Issue 駆動運用
 - GitHub 上に工程ごとのマイルストーンを作成する。

--- a/docs/test-results/2026-04-29_リリース工程完了レビュー.md
+++ b/docs/test-results/2026-04-29_リリース工程完了レビュー.md
@@ -1,0 +1,55 @@
+# リリース工程完了レビュー
+
+## 1. レビュー情報
+- 対象 Issue: `#18`
+- レビュー日: 2026-04-29
+- 対象工程: リリース
+- 対象バージョン: `v0.1.0`
+- 記録者: Codex
+
+## 2. 完了判断
+リリース工程は完了と判断する。
+
+`v0.1.0` の GitHub Release を作成し、アプリ本体 zip と SHA-256 checksum を公開した。公開後に Release metadata、asset 添付状態、zip / checksum のダウンロード、SHA-256 一致、必須ファイル、非同梱対象を確認した。
+
+## 3. 成果物
+- GitHub Release: `https://github.com/Sunmax0731/movie-telop-transcriber/releases/tag/v0.1.0`
+- 配布 zip: `movie-telop-transcriber-win-x64-v0.1.0.zip`
+- checksum: `movie-telop-transcriber-win-x64-v0.1.0.zip.sha256`
+- 配布構成: `docs/11_配布構成と同梱物.md`
+- 導入手順: `docs/12_導入手順書.md`
+- リリースノート: `docs/13_リリースノート.md`
+- 配布物作成スクリプト: `tools/release/New-ReleasePackage.ps1`
+- 配布物検証結果: `docs/test-results/2026-04-29_issue51_release_package.md`
+
+## 4. GitHub 状態
+- リリース工程の個別 Issue `#48`、`#49`、`#50`、`#51` は完了済み。
+- Release `v0.1.0` は draft ではなく、prerelease でもない。
+- Release target は `3bcd8363e991913040231b0e25fe4eda274768b0`。
+- open PR はない。
+- 残っている主な open Issue は `#98` タイムライン結合・分割 UI とプレビュー同期の再設計。
+
+## 5. 公開後検証
+| 項目 | 結果 |
+| --- | --- |
+| Release metadata 確認 | 成功 |
+| zip asset 添付確認 | 成功 |
+| checksum asset 添付確認 | 成功 |
+| Release からの asset download | 成功 |
+| SHA-256 一致 | 成功 |
+| 展開後必須ファイル確認 | 成功 |
+| `test-data/basic_telop/botirist.mp4` 非同梱確認 | 成功 |
+| `*.pdb` 非同梱確認 | 成功 |
+
+## 6. レビュー対象文書
+- ルート `AGENTS.md`
+- ルート `SKILL.md`
+- `README.md`
+- `docs/02_開発工程.md`
+- `docs/11_配布構成と同梱物.md`
+- `docs/12_導入手順書.md`
+- `docs/13_リリースノート.md`
+
+## 7. 後続
+- `#98` はリリース後対応として open のまま残す。
+- self-contained publish 出力の再調査、OCR ランタイムパックの分離配布、属性推定の高精度化、QCDS 評価対象動画の追加は後続改善候補として扱う。


### PR DESCRIPTION
## 概要
- `docs/test-results/2026-04-29_リリース工程完了レビュー.md` を追加し、`v0.1.0` 公開後の工程完了判断、成果物、GitHub 状態、公開後検証、後続 Issue を整理しました。
- README と `docs/02_開発工程.md` を `v0.1.0` 公開済み、次の主タスクは #98 という状態へ更新しました。

Closes #18

## 検証
- `gh issue list --repo Sunmax0731/movie-telop-transcriber --state open --json number,title,labels,url --limit 100`
- `gh pr list --repo Sunmax0731/movie-telop-transcriber --state open --json number,title,headRefName,url --limit 20`
- `gh release view v0.1.0 --repo Sunmax0731/movie-telop-transcriber --json tagName,name,url,isDraft,isPrerelease,targetCommitish,assets`
- Release asset download と SHA-256 一致確認
- `$term = [string]([char]0x52b9) + [string]([char]0x304f); rg -n $term README.md docs tools`
- `git diff --check`

## 後続
- #98 はリリース後対応として open のまま残します。