### PR TITLE
v0.1.1 インストーラ同梱版リリース準備

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,10 @@
 <Project>
   <PropertyGroup>
     <Platform Condition="'$(Platform)' == '' or '$(Platform)' == 'AnyCPU'">x64</Platform>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <Version>$(VersionPrefix)</Version>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <FileVersion>0.1.0.0</FileVersion>
+    <AssemblyVersion>0.1.1.0</AssemblyVersion>
+    <FileVersion>0.1.1.0</FileVersion>
     <InformationalVersion>$(VersionPrefix)</InformationalVersion>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ dotnet build src\MovieTelopTranscriber.sln -c Debug -p:Platform=x64
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass `
   -File .\tools\release\New-ReleasePackage.ps1 `
-  -Version 0.1.0
+  -Version 0.1.1
 ```
 
 生成物は `dist/` 配下に作成されます。配布 zip にはアプリ本体、docs、最小サンプル、インストーラを含めます。Python runtime、PaddleOCR package、OCR モデル本体は同梱せず、インストーラまたは手動手順で取得します。
@@ -185,7 +185,7 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass `
   -File .\tools\install\Install-MovieTelopTranscriber.ps1 `
-  -PackageZipPath .\dist\movie-telop-transcriber-win-x64-v0.1.0.zip `
+  -PackageZipPath .\dist\movie-telop-transcriber-win-x64-v0.1.1.zip `
   -Force
 ```
 
@@ -220,5 +220,5 @@ python tools\validation\evaluate_qcds_report.py `
 
 ### 現在の状態
 - 初期リリース `v0.1.0` は公開済み。
-- GitHub Release には `movie-telop-transcriber-win-x64-v0.1.0.zip` と checksum を配置済み。
+- インストーラ同梱版 `v0.1.1` をリリース対象として扱う。
 - リリース後の主な open Issue は、タイムライン結合 / 分割 UI とプレビュー同期の再設計である。

--- a/docs/02_開発工程.md
+++ b/docs/02_開発工程.md
@@ -150,6 +150,8 @@
 - `#50` で `docs/13_リリースノート.md` を作成し、`v0.1.0` の提供範囲、導入前提、既知制約、今後の予定を整理済み。
 - `#51` で `tools/release/New-ReleasePackage.ps1`、配布 zip、checksum、GitHub Release `v0.1.0` を整備済み。
 - GitHub Release: `https://github.com/Sunmax0731/movie-telop-transcriber/releases/tag/v0.1.0`
+- `#114` で README 再構成、導入インストーラ、PaddleOCR モデル取得 warmup を整備済み。
+- `#116` でインストーラ同梱版 `v0.1.1` の配布を進める。
 - リリース工程の親 Issue `#18` は、工程完了レビュー後に close する。
 - 次に着手する主な open Issue は `#98` タイムライン結合・分割 UI とプレビュー同期の再設計。
 

--- a/docs/13_リリースノート.md
+++ b/docs/13_リリースノート.md
@@ -1,19 +1,75 @@
 # リリースノート
 
 ## 1. 文書情報
-- 対象 Issue: `#50`
+- 対象 Issue: `#50`、`#116`
 - 作成日: 2026-04-29
-- 対象バージョン: `v0.1.0`
+- 最新対象バージョン: `v0.1.1`
 - 対象工程: リリース
 - 記録者: Codex
 
-## 2. リリース概要
+## 2. v0.1.1 リリース概要
+`v0.1.1` は、`v0.1.0` の初期機能を維持したまま、導入手順を簡略化するための配布改善リリースである。
+
+主な変更点:
+- リポジトリルートの `README.md` を、利用者向けと開発者向けの二部構成に再構成した。
+- PowerShell インストーラ `Install-MovieTelopTranscriber.ps1` を追加した。
+- インストーラでアプリ本体の取得、所定ディレクトリへの配置、PaddleOCR 用 Python 仮想環境作成、PaddlePaddle / PaddleOCR package 導入、OCR モデル取得、起動スクリプト作成、スタートメニュー登録を行えるようにした。
+- PaddleOCR worker に `--warmup-models` を追加し、モデル取得を明示的に実行できるようにした。
+- 配布 zip 内にインストーラを同梱し、GitHub Release asset としてもインストーラ単体を公開する。
+
+## 3. v0.1.1 配布物
+GitHub Release `v0.1.1` では、次の asset を公開対象とする。
+
+```text
+movie-telop-transcriber-win-x64-v0.1.1.zip
+movie-telop-transcriber-win-x64-v0.1.1.zip.sha256
+Install-MovieTelopTranscriber.ps1
+Install-MovieTelopTranscriber.ps1.sha256
+```
+
+アプリ本体 zip には、WinUI 3 アプリの Release build 出力一式、`tools/ocr/paddle_ocr_worker.py`、`Install-MovieTelopTranscriber.ps1`、利用者向けドキュメント、最小サンプルを含める。
+
+Python ランタイム、PaddlePaddle / PaddleOCR の Python package、PaddleOCR モデル本体はアプリ本体 zip には含めない。オンライン導入ではインストーラが利用者環境へ取得する。オフライン環境に持ち込む場合は、導入手順書に従って OCR runtime と `%USERPROFILE%\.paddlex` のモデルキャッシュを別途配置する。
+
+## 4. v0.1.1 導入前提
+- 対象 OS は Windows x64 とする。
+- アプリの TargetPlatformMinVersion は `10.0.17763.0` である。
+- Release build 出力は `.runtimeconfig.json` で .NET 10 runtime を参照するため、利用環境には .NET 10 Desktop Runtime x64 が必要である。
+- 標準の OCR 構成は、Python `3.10.x`、PaddlePaddle `3.2.0` CPU、PaddleOCR `3.5.0`、`PP-OCRv5_server_det` / `PP-OCRv5_server_rec`、`cpu` である。
+- 導入手順は `docs/12_導入手順書.md` を参照する。
+
+## 5. v0.1.1 の既知制約
+### 5.1 配布方式
+- `dotnet build -c Release -p:Platform=x64` の Release build 出力を配布対象とする。
+- `dotnet publish --self-contained true` の出力は、#46 の検証で `0xC000027B` により起動直後に終了したため、現時点では使わない。
+- アプリ本体 zip の展開サイズは Release build 出力を基準に約 600 MB 規模になる。
+
+### 5.2 インストーラ
+- インストーラのオンライン導入では、GitHub Release、PaddlePaddle wheel 配布元、PyPI、PaddleOCR モデル取得先へ接続できる必要がある。
+- Python 3.10 は事前に利用者環境へ導入されている前提である。既定では `py -3.10` を使う。
+- プロキシや社内ネットワーク制限がある端末では、オフライン導入手順で OCR runtime と `.paddlex` を事前配置する。
+
+### 5.3 OCR
+- PaddleOCR の Python 環境が未導入、または `MOVIE_TELOP_PADDLEOCR_PYTHON` が想定外の Python を指している場合、実動画 OCR は OCR エラーになる。
+- CPU 推論の処理時間は動画解像度、抽出間隔、検出しきい値、前処理設定、モデル配置状況により大きく変わる。
+- Windows OCR baseline worker は実装済みだが、日本語テロップの認識精度が不足したため、標準の実 OCR 経路としては PaddleOCR を推奨する。
+
+### 5.4 テロップ属性
+- `font_size` は OCR 矩形高さ相当の推定値であり、実フォントサイズではない。
+- `text_color`、`stroke_color`、`text_type` は、色や枠の暫定分類ラベルである。
+- `font_family` と `background_color` は `null` を許容する。
+- `segments.ass` は標準スタイル `Default` のみで出力する。テロップ属性に基づく詳細スタイル反映は後続実装で扱う。
+
+### 5.5 タイムライン編集
+- タイムライン上の編集と削除は、現在結果と再出力に反映できる。
+- 結合 / 分割 UI は、プレビュー同期を再設計するまで非表示とする。後続対応は `#98` で扱う。
+
+## 6. v0.1.0 初期リリース概要
 `v0.1.0` は、動画内テロップを抽出し、時刻付きテキストと初期属性情報を出力する Windows x64 向け初期リリースである。
 
-このリリースでは、WinUI 3 GUI から動画を選択し、フレーム抽出、PaddleOCR による OCR、セグメント統合、JSON / CSV / 字幕形式の出力までを一連の操作として実行できる。オフライン利用を前提に、アプリ本体、導入手順、既知制約、最小サンプルを配布物に含める。
+このリリースでは、WinUI 3 GUI から動画を選択し、フレーム抽出、PaddleOCR による OCR、セグメント統合、JSON / CSV / 字幕形式の出力までを一連の操作として実行できる。
 
-## 3. 提供範囲
-### 3.1 アプリ機能
+提供範囲:
 - WinUI 3 / MVVM 構成の GUI。
 - 動画メタデータ読み込みとフレーム抽出。
 - PaddleOCR PP-OCRv5 worker 連携による日本語 OCR。
@@ -23,69 +79,7 @@
 - タイムライン選択テロップのコピー、編集、削除。
 - 処理状況、経過時間、推定残り時間、失敗段階、エラー内容の表示。
 - 設定画面による言語、出力先、フレーム抽出間隔、PaddleOCR 前処理、検出しきい値の調整。
-
-### 3.2 OCR エンジン
-- 実動画 OCR の既定エンジンは PaddleOCR とする。
-- `MOVIE_TELOP_OCR_ENGINE=paddleocr` を明示した場合も PaddleOCR を使う。
-- `MOVIE_TELOP_OCR_ENGINE=json-sidecar` は、サンプル sidecar 検証モードとしてのみ扱う。
-- sidecar がない状態で `json-sidecar` を指定した場合は、`OCR_SIDECAR_NOT_FOUND` の OCR エラーとして扱う。
-
-### 3.3 出力
-- `segments.json`
-- `segments.csv`
-- `frames.csv`
-- `segments.srt`
-- `segments.vtt`
-- `segments.ass`
-- `logs/run.log`
-- `logs/summary.json`
-
-`segments.json` の `run_metadata.application_version` は `0.1.0` として出力する。
-
-## 4. 導入前提
-- 対象 OS は Windows x64 とする。
-- アプリの TargetPlatformMinVersion は `10.0.17763.0` である。
-- Release build 出力は `.runtimeconfig.json` で .NET 10 runtime を参照するため、利用環境には .NET 10 Desktop Runtime x64 が必要である。
-- PaddleOCR を使う場合は、Python 3.10 系、PaddlePaddle、PaddleOCR、PP-OCRv5 モデルの事前導入が必要である。
-- 動作確認済みの OCR 構成は、Python `3.10.6`、PaddlePaddle `3.2.0` CPU、PaddleOCR `3.5.0`、`PP-OCRv5_server_det` / `PP-OCRv5_server_rec`、`cpu` である。
-- 導入手順は `docs/12_導入手順書.md` を参照する。
-
-## 5. 配布物
-GitHub Release `v0.1.0` では、次のアプリ本体 zip を公開対象とする。
-
-```text
-movie-telop-transcriber-win-x64-v0.1.0.zip
-```
-
-アプリ本体 zip には、WinUI 3 アプリの Release build 出力一式、`tools/ocr/paddle_ocr_worker.py`、利用者向けドキュメント、最小サンプルを含める。
-
-アプリ本体 zip には、Python ランタイム、PaddlePaddle / PaddleOCR の Python package、PaddleOCR モデル本体は含めない。オフライン環境に持ち込む場合は、導入手順書に従って OCR ランタイムと `%USERPROFILE%\.paddlex` のモデルキャッシュを別途配置する。
-
-## 6. 既知制約
-### 6.1 配布方式
-- 初期リリースでは `dotnet build -c Release -p:Platform=x64` の Release build 出力を配布対象とする。
-- `dotnet publish --self-contained true` の出力は、#46 の検証で `0xC000027B` により起動直後に終了したため、初期リリースでは使わない。
-- アプリ本体 zip の展開サイズは Release build 出力を基準に約 600 MB 規模になる。
-
-### 6.2 OCR
-- PaddleOCR の Python 環境が未導入、または `MOVIE_TELOP_PADDLEOCR_PYTHON` が想定外の Python を指している場合、実動画 OCR は OCR エラーになる。
-- CPU 推論の処理時間は動画解像度、抽出間隔、検出しきい値、前処理設定、モデル配置状況により大きく変わる。
-- Windows OCR baseline worker は実装済みだが、日本語テロップの認識精度が不足したため、初期リリースの実 OCR 経路としては PaddleOCR を推奨する。
-
-### 6.3 テロップ属性
-- `font_size` は OCR 矩形高さ相当の推定値であり、実フォントサイズではない。
-- `text_color`、`stroke_color`、`text_type` は、色や枠の暫定分類ラベルである。
-- `font_family` と `background_color` は `null` を許容する。
-- `segments.ass` は標準スタイル `Default` のみで出力する。テロップ属性に基づく詳細スタイル反映は後続実装で扱う。
-
-### 6.4 タイムライン編集
-- タイムライン上の編集と削除は、現在結果と再出力に反映できる。
-- 結合 / 分割 UI は、プレビュー同期を再設計するまで非表示とする。後続対応は `#98` で扱う。
-
-### 6.5 QCDS 評価
-- QCDS の初期レポートは `basic_telop` 1 本を代表動画として扱う。
-- 現時点の QCDS スコアだけでは、すべての実動画パターンに対する品質を判断できない。
-- 評価対象動画と実測レポートは後続で追加する。
+- `segments.json`、`segments.csv`、`frames.csv`、`segments.srt`、`segments.vtt`、`segments.ass`、`logs/run.log`、`logs/summary.json` の出力。
 
 ## 7. 参照ドキュメント
 - `docs/11_配布構成と同梱物.md`
@@ -96,6 +90,5 @@ movie-telop-transcriber-win-x64-v0.1.0.zip
 - `docs/spec/07_テロップ属性リリース範囲.md`
 
 ## 8. 今後の予定
-- `#51` で GitHub Release `v0.1.0` を作成し、アプリ本体 zip を公開する。
 - `#98` でタイムライン結合 / 分割 UI とプレビュー同期を再設計する。
 - self-contained publish 出力の再調査、OCR ランタイムパックの分離配布、属性推定の高精度化、QCDS 評価対象動画の追加を後続改善候補として扱う。

--- a/docs/spec/04_出力仕様.md
+++ b/docs/spec/04_出力仕様.md
@@ -94,7 +94,7 @@
   ],
   "run_metadata": {
     "generated_at": "2026-04-28T07:00:00+09:00",
-    "application_version": "0.1.0",
+    "application_version": "0.1.1",
     "processing_time_ms": 18250
   }
 }

--- a/docs/test-results/2026-04-29_issue116_v0.1.1_release.md
+++ b/docs/test-results/2026-04-29_issue116_v0.1.1_release.md
@@ -1,0 +1,48 @@
+# Issue #116 v0.1.1 インストーラ同梱版リリース検証
+
+## 1. 文書情報
+- 対象 Issue: `#116`
+- 実施日: 2026-04-29
+- 対象バージョン: `v0.1.1`
+- 対象工程: リリース後改善
+- 記録者: Codex
+
+## 2. 対象変更
+- `Directory.Build.props` のアプリバージョンを `0.1.1` に更新した。
+- インストーラと配布物作成スクリプトの既定バージョンを `0.1.1` に更新した。
+- README、出力仕様、開発工程、リリースノートを `v0.1.1` 向けに更新した。
+- `v0.1.1` の配布 zip、zip checksum、installer ps1、installer checksum を作成した。
+
+## 3. 検証結果
+| 項目 | コマンド | 結果 |
+| --- | --- | --- |
+| Release build | `dotnet build src\MovieTelopTranscriber.sln -c Release -p:Platform=x64` | 成功。警告 0、エラー 0 |
+| インストーラ計画出力 | `powershell -NoProfile -ExecutionPolicy Bypass -File .\tools\install\Install-MovieTelopTranscriber.ps1 -WhatIf` | 成功。既定バージョン `0.1.1` と `v0.1.1` release URL を確認 |
+| PaddleOCR worker CLI | `py -3.10 .\tools\ocr\paddle_ocr_worker.py --help` | 成功。`--warmup-models` が表示されることを確認 |
+| 禁止表現確認 | `rg` による対象語検索 | 該当なし |
+| 配布物作成 | `powershell -NoProfile -ExecutionPolicy Bypass -File .\tools\release\New-ReleasePackage.ps1 -Version 0.1.1 -SkipBuild` | 成功。zip、zip checksum、installer、installer checksum を生成 |
+| zip 内容確認 | `Expand-Archive` 後に必須ファイルを `Test-Path` | 成功。installer、app exe、PaddleOCR worker、README、導入手順、リリースノート、sample mp4 を確認 |
+| zip checksum | `Get-FileHash` と `.zip.sha256` の照合 | 一致 |
+| installer checksum | `Get-FileHash` と `.ps1.sha256` の照合 | 一致 |
+| Assembly metadata | `MovieTelopTranscriber.App.AssemblyInfo.cs` の確認 | `AssemblyInformationalVersion("0.1.1")`、`AssemblyVersion("0.1.1.0")`、`AssemblyFileVersion("0.1.1.0")` |
+| ローカル zip 導入確認 | `Install-MovieTelopTranscriber.ps1 -PackageZipPath .\dist\movie-telop-transcriber-win-x64-v0.1.1.zip -InstallRoot .\temp\installer-smoke-v0.1.1\MovieTelopTranscriber -OcrRuntimeRoot .\temp\installer-smoke-v0.1.1\ocr-runtime -SkipOcrSetup -SkipModelDownload -NoStartMenuShortcut -Force` | 成功。アプリ配置、worker 配置、起動スクリプト生成を確認 |
+
+## 4. 配布物作成結果
+`New-ReleasePackage.ps1` の出力:
+
+| 項目 | 値 |
+| --- | --- |
+| PackageName | `movie-telop-transcriber-win-x64-v0.1.1` |
+| ZipPath | `dist\movie-telop-transcriber-win-x64-v0.1.1.zip` |
+| ChecksumPath | `dist\movie-telop-transcriber-win-x64-v0.1.1.zip.sha256` |
+| InstallerPath | `dist\Install-MovieTelopTranscriber.ps1` |
+| InstallerChecksumPath | `dist\Install-MovieTelopTranscriber.ps1.sha256` |
+| FileCount | `1097` |
+| ExpandedSizeBytes | `634691406` |
+| ZipSizeBytes | `246784830` |
+| ZipSha256 | `b338760f621ff0ad5dec3e912cbb4e5058c6a6c511e8e455847db3522bafa30b` |
+| InstallerSha256 | `ab41e372e0101fd37132a25739c8c58cf5c1080c5828efe5af0998b51d44d6c6` |
+
+## 5. 未実施範囲
+- 実ネットワーク経由の PaddleOCR package 導入とモデル取得は実行していない。
+- スタートメニューショートカット作成は、検証環境を汚さないため `-NoStartMenuShortcut` で省略した。

--- a/tools/install/Install-MovieTelopTranscriber.ps1
+++ b/tools/install/Install-MovieTelopTranscriber.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
-    [string]$Version = "0.1.0",
+    [string]$Version = "0.1.1",
     [string]$InstallRoot = (Join-Path $env:LOCALAPPDATA "Programs\MovieTelopTranscriber"),
     [string]$OcrRuntimeRoot = (Join-Path $env:LOCALAPPDATA "Programs\MovieTelopTranscriber\ocr-runtime"),
     [string]$DownloadRoot = (Join-Path $env:TEMP "movie-telop-transcriber-install"),

--- a/tools/release/New-ReleasePackage.ps1
+++ b/tools/release/New-ReleasePackage.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$Version = "0.1.0",
+    [string]$Version = "0.1.1",
     [ValidateSet("Debug", "Release")]
     [string]$Configuration = "Release",
     [ValidateSet("x64")]


### PR DESCRIPTION
## 概要
- アプリバージョン、インストーラ既定バージョン、配布スクリプト既定バージョンを `0.1.1` に更新
- README、リリースノート、開発工程、出力仕様を `v0.1.1` 向けに更新
- `v0.1.1` の配布物作成と smoke 結果を `docs/test-results/2026-04-29_issue116_v0.1.1_release.md` に記録

## 検証
- `dotnet build src\MovieTelopTranscriber.sln -c Release -p:Platform=x64`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\tools\install\Install-MovieTelopTranscriber.ps1 -WhatIf`
- `py -3.10 .\tools\ocr\paddle_ocr_worker.py --help`
- 禁止表現検索: 該当なし
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\tools\release\New-ReleasePackage.ps1 -Version 0.1.1 -SkipBuild`
- zip 展開後の必須ファイル確認
- zip / installer checksum 照合
- Assembly metadata `0.1.1` 確認
- ローカル zip を使った installer smoke

Closes #116