### PR TITLE
EXE直起動用の settings.json 導線を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@
 - OCR モデル: `PP-OCRv5_server_det`、`PP-OCRv5_server_rec`
 
 ### 導入方法
-推奨は PowerShell インストーラを使う方法です。アプリ本体を所定のディレクトリへ配置し、PaddleOCR 用の Python 仮想環境、Python package、OCR モデル取得までをまとめて実行します。
+推奨は配布物に含まれる `Install-MovieTelopTranscriber.cmd` をダブルクリックして開始する方法です。内部では PowerShell インストーラを呼び出し、アプリ本体の配置、PaddleOCR 用 Python 仮想環境、Python package、OCR モデル取得、起動設定ファイル作成までをまとめて実行します。
+
+PowerShell から直接実行する場合は次を使います。
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass `
@@ -36,6 +38,7 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 | --- | --- |
 | アプリ本体 | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber` |
 | OCR runtime | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\ocr-runtime` |
+| 起動設定ファイル | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\app\movie-telop-transcriber.settings.json` |
 | 起動スクリプト | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\Start-MovieTelopTranscriber.ps1` |
 | OCR モデル | `%USERPROFILE%\.paddlex\official_models` |
 
@@ -59,14 +62,9 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 手動導入やオフライン導入が必要な場合は、[docs/12_導入手順書.md](docs/12_導入手順書.md) を参照してください。
 
 ### 起動方法
-インストーラを使った場合は、スタートメニューの `Movie Telop Transcriber` から起動できます。PowerShell から起動する場合は、生成された起動スクリプトを実行します。
+インストーラを使った場合は、スタートメニューの `Movie Telop Transcriber` または `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\app\MovieTelopTranscriber.App.exe` をダブルクリックして起動できます。
 
-```powershell
-powershell -NoProfile -ExecutionPolicy Bypass `
-  -File "$env:LOCALAPPDATA\Programs\MovieTelopTranscriber\Start-MovieTelopTranscriber.ps1"
-```
-
-この起動スクリプトは、PaddleOCR 用の環境変数を設定してからアプリを起動します。
+アプリは起動時に `movie-telop-transcriber.settings.json` を読み込み、PaddleOCR 用 Python、worker script、OCR 設定を解決します。PowerShell 起動スクリプトは互換用として残りますが、通常利用では不要です。
 
 ### 基本的な使い方
 1. アプリを起動する。
@@ -85,7 +83,7 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 | インストーラが PowerShell 実行ポリシーで止まる | 起動コマンドに `-ExecutionPolicy Bypass` があるか | README の導入コマンドをそのまま実行する |
 | アプリが起動しない | .NET 10 Desktop Runtime x64 が入っているか | `dotnet --list-runtimes` で `Microsoft.WindowsDesktop.App 10.0.x` を確認し、不足していれば導入する |
 | インストーラが Python を見つけられない | `py -3.10` で Python 3.10 が起動できるか | Python 3.10 を導入するか、`-PythonCommand` と `-PythonArguments` で利用する Python を指定する |
-| OCR が `paddleocr` を import できない | 起動スクリプトの `MOVIE_TELOP_PADDLEOCR_PYTHON` が仮想環境を指しているか | インストーラを再実行する。手動導入の場合は `pip show paddleocr` を確認する |
+| OCR が `paddleocr` を import できない | `app\movie-telop-transcriber.settings.json` の `paddleOcr.pythonPath` が仮想環境を指しているか | インストーラを再実行する。手動導入の場合は `pip show paddleocr` を確認する |
 | 初回 OCR でモデル取得に失敗する | ネットワーク接続、プロキシ、`%USERPROFILE%\.paddlex` への書き込み権限 | ネットワーク接続できる環境でインストーラを再実行する。オフライン端末ではモデル取得済みの `.paddlex` をコピーする |
 | `ocr_engine=json-sidecar` になっている | `MOVIE_TELOP_OCR_ENGINE=json-sidecar` を設定したまま起動していないか | 実動画 OCR では未指定または `paddleocr` にする |
 | 出力先フォルダの作成に失敗する | 指定フォルダに書き込み権限があるか | 利用者が書き込めるフォルダを指定する。失敗時は `OUTPUT_ROOT_UNAVAILABLE` として表示される |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - OCR モデル: `PP-OCRv5_server_det`、`PP-OCRv5_server_rec`
 
 ### 導入方法
-推奨は配布物に含まれる `Install-MovieTelopTranscriber.cmd` をダブルクリックして開始する方法です。内部では PowerShell インストーラを呼び出し、アプリ本体の配置、PaddleOCR 用 Python 仮想環境、Python package、OCR モデル取得、起動設定ファイル作成までをまとめて実行します。
+推奨は、インストールしたい親ディレクトリで配布物に含まれる `Install-MovieTelopTranscriber.cmd` を実行する方法です。内部では PowerShell インストーラを呼び出し、実行したディレクトリ配下に `MovieTelopTranscriber` フォルダを作成し、アプリ本体の配置、PaddleOCR 用 Python 仮想環境、Python package、OCR モデル取得、起動設定ファイル作成までをまとめて実行します。
 
 PowerShell から直接実行する場合は次を使います。
 
@@ -36,10 +36,10 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 
 | 種別 | 既定パス |
 | --- | --- |
-| アプリ本体 | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber` |
-| OCR runtime | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\ocr-runtime` |
-| 起動設定ファイル | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\app\movie-telop-transcriber.settings.json` |
-| 起動スクリプト | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\Start-MovieTelopTranscriber.ps1` |
+| アプリ本体 | `<実行ディレクトリ>\MovieTelopTranscriber` |
+| OCR runtime | `<実行ディレクトリ>\MovieTelopTranscriber\ocr-runtime` |
+| 起動設定ファイル | `<実行ディレクトリ>\MovieTelopTranscriber\app\movie-telop-transcriber.settings.json` |
+| 起動スクリプト | `<実行ディレクトリ>\MovieTelopTranscriber\Start-MovieTelopTranscriber.ps1` |
 | OCR モデル | `%USERPROFILE%\.paddlex\official_models` |
 
 再インストールする場合は `-Force` を付けます。
@@ -62,7 +62,7 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 手動導入やオフライン導入が必要な場合は、[docs/12_導入手順書.md](docs/12_導入手順書.md) を参照してください。
 
 ### 起動方法
-インストーラを使った場合は、スタートメニューの `Movie Telop Transcriber` または `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\app\MovieTelopTranscriber.App.exe` をダブルクリックして起動できます。
+インストーラを使った場合は、スタートメニューの `Movie Telop Transcriber` または `<実行ディレクトリ>\MovieTelopTranscriber\app\MovieTelopTranscriber.App.exe` をダブルクリックして起動できます。
 
 アプリは起動時に `movie-telop-transcriber.settings.json` を読み込み、PaddleOCR 用 Python、worker script、OCR 設定を解決します。PowerShell 起動スクリプトは互換用として残りますが、通常利用では不要です。
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,19 @@
 - OCR モデル: `PP-OCRv5_server_det`、`PP-OCRv5_server_rec`
 
 ### 導入方法
-推奨は、インストールしたい親ディレクトリで配布物に含まれる `Install-MovieTelopTranscriber.cmd` を実行する方法です。内部では PowerShell インストーラを呼び出し、実行したディレクトリ配下に `MovieTelopTranscriber` フォルダを作成し、アプリ本体の配置、PaddleOCR 用 Python 仮想環境、Python package、OCR モデル取得、起動設定ファイル作成までをまとめて実行します。
+最短手順は次の 3 ステップです。
 
-PowerShell から直接実行する場合は次を使います。
+1. 配布 zip を展開する。
+2. インストールしたい親ディレクトリで `Install-MovieTelopTranscriber.cmd` をダブルクリックする。
+3. 作成された `MovieTelopTranscriber\app\MovieTelopTranscriber.App.exe` をダブルクリックして起動する。
+
+`Install-MovieTelopTranscriber.cmd` は内部で PowerShell インストーラを呼び出し、実行したディレクトリ配下に `MovieTelopTranscriber` フォルダを作成します。その中へアプリ本体、PaddleOCR 用 Python 仮想環境、Python package、OCR モデル、起動設定ファイルをまとめて配置します。
+
+PowerShell から直接実行する場合は、配布物を展開したフォルダで次を使います。
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass `
-  -File .\tools\install\Install-MovieTelopTranscriber.ps1
+  -File .\Install-MovieTelopTranscriber.ps1
 ```
 
 既定の配置先は次のとおりです。
@@ -42,24 +48,24 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 | 起動スクリプト | `<実行ディレクトリ>\MovieTelopTranscriber\Start-MovieTelopTranscriber.ps1` |
 | OCR モデル | `%USERPROFILE%\.paddlex\official_models` |
 
-再インストールする場合は `-Force` を付けます。
+同じ場所へ再インストールする場合は `-Force` を付けます。
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass `
-  -File .\tools\install\Install-MovieTelopTranscriber.ps1 `
+  -File .\Install-MovieTelopTranscriber.ps1 `
   -Force
 ```
 
-配置先を変える場合は `-InstallRoot` と `-OcrRuntimeRoot` を指定します。
+配布物の場所とは別のディレクトリへ入れたい場合は `-InstallRoot` と `-OcrRuntimeRoot` を指定します。
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass `
-  -File .\tools\install\Install-MovieTelopTranscriber.ps1 `
+  -File .\Install-MovieTelopTranscriber.ps1 `
   -InstallRoot D:\Tools\movie-telop-transcriber `
   -OcrRuntimeRoot D:\Tools\movie-telop-ocr-runtime
 ```
 
-手動導入やオフライン導入が必要な場合は、[docs/12_導入手順書.md](docs/12_導入手順書.md) を参照してください。
+配布 zip ではなくリポジトリ内の開発用スクリプトを直接使う場合は `tools/install/Install-MovieTelopTranscriber.ps1` を実行します。手動導入やオフライン導入が必要な場合は、[docs/12_導入手順書.md](docs/12_導入手順書.md) を参照してください。
 
 ### 起動方法
 インストーラを使った場合は、スタートメニューの `Movie Telop Transcriber` または `<実行ディレクトリ>\MovieTelopTranscriber\app\MovieTelopTranscriber.App.exe` をダブルクリックして起動できます。

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 
 アプリは起動時に `movie-telop-transcriber.settings.json` を読み込み、PaddleOCR 用 Python、worker script、OCR 設定を解決します。PowerShell 起動スクリプトは互換用として残りますが、通常利用では不要です。
 
+### アンインストール
+導入先の `MovieTelopTranscriber` フォルダにある `Uninstall-MovieTelopTranscriber.cmd` を実行すると、アプリ本体、OCR runtime、起動設定、ショートカット、導入先を指すユーザー環境変数を削除します。
+
+PaddleOCR モデルキャッシュは、この導入で新規取得したものだけを削除します。共有キャッシュ全体を削除したい場合は、PowerShell から `Uninstall-MovieTelopTranscriber.ps1 -RemoveSharedModelCache` を実行します。
+
 ### 基本的な使い方
 1. アプリを起動する。
 2. 入力動画を選択する。

--- a/docs/02_開発工程.md
+++ b/docs/02_開発工程.md
@@ -152,8 +152,10 @@
 - GitHub Release: `https://github.com/Sunmax0731/movie-telop-transcriber/releases/tag/v0.1.0`
 - `#114` で README 再構成、導入インストーラ、PaddleOCR モデル取得 warmup を整備済み。
 - `#116` でインストーラ同梱版 `v0.1.1` の配布を進める。
+- `#121` は一般利用者向け導入・起動導線の改善親 Issue。
+- `#122` では `EXE` 直起動と `movie-telop-transcriber.settings.json` による OCR 設定解決へ移行する。
 - リリース工程の親 Issue `#18` は、工程完了レビュー後に close する。
-- 次に着手する主な open Issue は `#98` タイムライン結合・分割 UI とプレビュー同期の再設計。
+- 次に着手する主な open Issue は `#121` 配下の `#122`、その後に `#98` タイムライン結合・分割 UI とプレビュー同期の再設計。
 
 ## 5. Issue 駆動運用
 - GitHub 上に工程ごとのマイルストーンを作成する。

--- a/docs/07_実装メモ.md
+++ b/docs/07_実装メモ.md
@@ -6,6 +6,7 @@
 ## 2. OCR ワーカー接続
 - アプリ本体は `IOcrWorkerClient` 経由で OCR を呼び出す。
 - アプリ起動時に `app\movie-telop-transcriber.settings.json` を読み込み、OCR engine、Python path、worker script、PaddleOCR 設定をプロセス内へ反映する。
+- インストーラは `movie-telop-transcriber.installation.json` を生成し、アンインストーラーはその manifest を参照して削除対象と新規取得モデルを判断する。
 - `MOVIE_TELOP_OCR_ENGINE=paddleocr` の場合は `PaddleOcrWorkerClient` を使用する。
 - `MOVIE_TELOP_OCR_ENGINE` が未指定で `MOVIE_TELOP_OCR_WORKER` も未指定の場合は、実動画 OCR の既定として `PaddleOcrWorkerClient` を使用する。
 - `MOVIE_TELOP_OCR_ENGINE=json-sidecar` など PaddleOCR 以外を明示した場合、または `MOVIE_TELOP_OCR_WORKER` を指定した場合は `ProcessOcrWorkerClient` を使用する。
@@ -78,6 +79,7 @@
 ## 9. 後続工程で再評価する項目
 - OCR モデルや PaddleOCR Python ランタイムは、#48 で初期リリースのアプリ本体 zip には同梱しない方針にした。オンライン導入とオフライン事前配置の手順は `docs/12_導入手順書.md` に整理済み。
 - #122 では、利用者が `MovieTelopTranscriber.App.exe` を直接起動できるよう、インストーラが `movie-telop-transcriber.settings.json` を生成し、`EXE` 側が起動時に参照する構成へ変更した。
+- 同じく #122 で、`Uninstall-MovieTelopTranscriber.ps1` / `.cmd` を追加し、導入先フォルダ、起動設定、ショートカット、導入先を指すユーザー環境変数、新規取得モデルを戻せるようにした。
 - PaddleOCR の速度最適化、ONNX Runtime 化、または Tesseract fallback の要否。
 - 色属性推定の画像解析方式。
 - フレーム単位結果をセグメント単位へ統合する代表値算出方式。

--- a/docs/07_実装メモ.md
+++ b/docs/07_実装メモ.md
@@ -5,6 +5,7 @@
 
 ## 2. OCR ワーカー接続
 - アプリ本体は `IOcrWorkerClient` 経由で OCR を呼び出す。
+- アプリ起動時に `app\movie-telop-transcriber.settings.json` を読み込み、OCR engine、Python path、worker script、PaddleOCR 設定をプロセス内へ反映する。
 - `MOVIE_TELOP_OCR_ENGINE=paddleocr` の場合は `PaddleOcrWorkerClient` を使用する。
 - `MOVIE_TELOP_OCR_ENGINE` が未指定で `MOVIE_TELOP_OCR_WORKER` も未指定の場合は、実動画 OCR の既定として `PaddleOcrWorkerClient` を使用する。
 - `MOVIE_TELOP_OCR_ENGINE=json-sidecar` など PaddleOCR 以外を明示した場合、または `MOVIE_TELOP_OCR_WORKER` を指定した場合は `ProcessOcrWorkerClient` を使用する。
@@ -19,6 +20,7 @@
 - PaddleOCR worker は手動クロップを使わず、フルフレームに対する自動前処理としてコントラスト補正、シャープ化を適用できる。拡大率は `1.0` 固定とする。
 - PaddleOCR の検出閾値、検出ボックス閾値、unclip ratio、limit side length、文字方向分類、文書ゆがみ補正は環境変数と設定画面から調整できる。
 - `PaddleOcrWorkerClient` は PaddleOCR 関連の設定差分を検出した場合、常駐 worker を再起動して次の OCR 実行へ反映する。
+- `movie-telop-transcriber.settings.json` がない場合、または JSON 読み込みに失敗した場合は、従来どおり環境変数側の設定を使う。
 - Windows 標準 OCR を使う baseline worker は `MovieTelopTranscriber.Ocr.Windows` として追加済み。
 - Windows OCR worker は `Windows.Media.Ocr` を使い、行単位の検出結果を共通 OCR 契約へ変換する。
 
@@ -75,6 +77,7 @@
 
 ## 9. 後続工程で再評価する項目
 - OCR モデルや PaddleOCR Python ランタイムは、#48 で初期リリースのアプリ本体 zip には同梱しない方針にした。オンライン導入とオフライン事前配置の手順は `docs/12_導入手順書.md` に整理済み。
+- #122 では、利用者が `MovieTelopTranscriber.App.exe` を直接起動できるよう、インストーラが `movie-telop-transcriber.settings.json` を生成し、`EXE` 側が起動時に参照する構成へ変更した。
 - PaddleOCR の速度最適化、ONNX Runtime 化、または Tesseract fallback の要否。
 - 色属性推定の画像解析方式。
 - フレーム単位結果をセグメント単位へ統合する代表値算出方式。

--- a/docs/12_導入手順書.md
+++ b/docs/12_導入手順書.md
@@ -9,7 +9,7 @@
 ## 2. 対象
 `movie-telop-transcriber` を Windows x64 環境へ導入し、実動画 OCR を実行できる状態にする手順を示す。
 
-推奨手順は配布物に含まれる `Install-MovieTelopTranscriber.cmd` から開始するオンライン導入である。内部のインストーラはアプリ本体を所定のディレクトリへ配置し、PaddleOCR 用 Python 仮想環境、PaddlePaddle / PaddleOCR package、OCR モデル取得、起動設定ファイル作成、スタートメニュー登録をまとめて行う。
+推奨手順は、インストールしたい親ディレクトリで配布物に含まれる `Install-MovieTelopTranscriber.cmd` から開始するオンライン導入である。内部のインストーラは、実行したディレクトリ配下に `MovieTelopTranscriber` フォルダを作成し、PaddleOCR 用 Python 仮想環境、PaddlePaddle / PaddleOCR package、OCR モデル取得、起動設定ファイル作成、スタートメニュー登録をまとめて行う。
 
 手動導入とオフライン導入は、ネットワーク制限や管理された端末でインストーラを使えない場合のフォールバックとして扱う。
 
@@ -73,10 +73,10 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 
 | 種別 | 既定パス |
 | --- | --- |
-| アプリ本体 | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber` |
-| OCR runtime | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\ocr-runtime` |
-| 起動設定ファイル | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\app\movie-telop-transcriber.settings.json` |
-| 起動スクリプト | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\Start-MovieTelopTranscriber.ps1` |
+| アプリ本体 | `<実行ディレクトリ>\MovieTelopTranscriber` |
+| OCR runtime | `<実行ディレクトリ>\MovieTelopTranscriber\ocr-runtime` |
+| 起動設定ファイル | `<実行ディレクトリ>\MovieTelopTranscriber\app\movie-telop-transcriber.settings.json` |
+| 起動スクリプト | `<実行ディレクトリ>\MovieTelopTranscriber\Start-MovieTelopTranscriber.ps1` |
 | OCR モデル | `%USERPROFILE%\.paddlex\official_models` |
 
 インストーラは次を実行する。

--- a/docs/12_導入手順書.md
+++ b/docs/12_導入手順書.md
@@ -21,6 +21,7 @@ GitHub Release から次の配布物を取得する。
 | `movie-telop-transcriber-win-x64-v<version>.zip` | 必須 | アプリ本体、WinUI / Windows App SDK 関連 DLL、OpenCVSharp 関連 DLL、PaddleOCR worker script、利用者向け文書、最小サンプルを含む |
 | `Install-MovieTelopTranscriber.cmd` | 推奨 | ダブルクリックで PowerShell インストーラを開始する |
 | `Install-MovieTelopTranscriber.ps1` | 代替 | アプリ本体 zip の取得、配置、PaddleOCR runtime 準備、モデル取得、起動設定ファイル作成を行う |
+| `Uninstall-MovieTelopTranscriber.cmd` | 同梱 | 導入先からアンインストーラーを起動する |
 | PaddleOCR ランタイムパック | 任意 | オフライン導入用に Python 環境、Python package、PaddleOCR モデルを別 zip として配布する場合に使う |
 
 現行のアプリ本体 zip には Python runtime、PaddlePaddle / PaddleOCR の Python package、PaddleOCR モデル本体を同梱しない。オンライン導入ではインストーラがインターネット経由で取得する。
@@ -172,6 +173,24 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 ```
 
 PowerShell 起動スクリプトを使う場合も、実際の OCR 解決元はこの設定ファイルである。
+
+## 6.1 アンインストール
+導入先の `MovieTelopTranscriber` フォルダにある `Uninstall-MovieTelopTranscriber.cmd` を実行する。
+
+アンインストーラーは次を削除する。
+
+1. `MovieTelopTranscriber` 配下のアプリ本体、文書、サンプル、OCR runtime、起動設定、ランチャー、アンインストーラー自身
+2. スタートメニューの `Movie Telop Transcriber` ショートカット
+3. この導入先を指している `MOVIE_TELOP_PADDLEOCR_PYTHON`、`MOVIE_TELOP_PADDLEOCR_SCRIPT`、`MOVIE_TELOP_OCR_WORKER` のユーザー環境変数
+4. この導入で新規取得した PaddleOCR モデルディレクトリ
+
+共有モデルキャッシュもまとめて削除したい場合は、PowerShell から次を実行する。
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass `
+  -File .\MovieTelopTranscriber\Uninstall-MovieTelopTranscriber.ps1 `
+  -RemoveSharedModelCache
+```
 
 ## 7. 初回確認
 1. アプリを起動する。

--- a/docs/12_導入手順書.md
+++ b/docs/12_導入手順書.md
@@ -1,7 +1,7 @@
 # 導入手順書
 
 ## 1. 文書情報
-- 対象 Issue: `#49`、`#114`
+- 対象 Issue: `#49`、`#114`、`#122`
 - 作成日: 2026-04-29
 - 対象工程: リリース
 - 記録者: Codex
@@ -9,7 +9,7 @@
 ## 2. 対象
 `movie-telop-transcriber` を Windows x64 環境へ導入し、実動画 OCR を実行できる状態にする手順を示す。
 
-推奨手順は PowerShell インストーラによるオンライン導入である。インストーラはアプリ本体を所定のディレクトリへ配置し、PaddleOCR 用 Python 仮想環境、PaddlePaddle / PaddleOCR package、OCR モデル取得、起動スクリプト作成、スタートメニュー登録をまとめて行う。
+推奨手順は配布物に含まれる `Install-MovieTelopTranscriber.cmd` から開始するオンライン導入である。内部のインストーラはアプリ本体を所定のディレクトリへ配置し、PaddleOCR 用 Python 仮想環境、PaddlePaddle / PaddleOCR package、OCR モデル取得、起動設定ファイル作成、スタートメニュー登録をまとめて行う。
 
 手動導入とオフライン導入は、ネットワーク制限や管理された端末でインストーラを使えない場合のフォールバックとして扱う。
 
@@ -19,7 +19,8 @@ GitHub Release から次の配布物を取得する。
 | 配布物 | 必須 | 用途 |
 | --- | --- | --- |
 | `movie-telop-transcriber-win-x64-v<version>.zip` | 必須 | アプリ本体、WinUI / Windows App SDK 関連 DLL、OpenCVSharp 関連 DLL、PaddleOCR worker script、利用者向け文書、最小サンプルを含む |
-| `Install-MovieTelopTranscriber.ps1` | 推奨 | アプリ本体 zip の取得、配置、PaddleOCR runtime 準備、モデル取得、起動スクリプト作成を行う |
+| `Install-MovieTelopTranscriber.cmd` | 推奨 | ダブルクリックで PowerShell インストーラを開始する |
+| `Install-MovieTelopTranscriber.ps1` | 代替 | アプリ本体 zip の取得、配置、PaddleOCR runtime 準備、モデル取得、起動設定ファイル作成を行う |
 | PaddleOCR ランタイムパック | 任意 | オフライン導入用に Python 環境、Python package、PaddleOCR モデルを別 zip として配布する場合に使う |
 
 現行のアプリ本体 zip には Python runtime、PaddlePaddle / PaddleOCR の Python package、PaddleOCR モデル本体を同梱しない。オンライン導入ではインストーラがインターネット経由で取得する。
@@ -61,7 +62,7 @@ GPU 利用、別 Python version、別 PaddleOCR version は標準導入手順の
 
 ## 5. インストーラによる導入
 ### 5.1 標準導入
-リポジトリまたは配布物に含まれる `tools/install/Install-MovieTelopTranscriber.ps1` を実行する。
+配布物に含まれる `Install-MovieTelopTranscriber.cmd` をダブルクリックする。PowerShell から直接実行したい場合は `Install-MovieTelopTranscriber.ps1` を使う。
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass `
@@ -74,6 +75,7 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 | --- | --- |
 | アプリ本体 | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber` |
 | OCR runtime | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\ocr-runtime` |
+| 起動設定ファイル | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\app\movie-telop-transcriber.settings.json` |
 | 起動スクリプト | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\Start-MovieTelopTranscriber.ps1` |
 | OCR モデル | `%USERPROFILE%\.paddlex\official_models` |
 
@@ -84,8 +86,9 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 3. Python 3.10 の仮想環境を作成する。
 4. `paddlepaddle==3.2.0` と `paddleocr==3.5.0` を導入する。
 5. `paddle_ocr_worker.py --warmup-models --warmup-language ja` を実行し、PaddleOCR モデルを取得する。
-6. PaddleOCR 用環境変数を設定する起動スクリプトを作成する。
-7. スタートメニューにショートカットを作成する。
+6. `app\movie-telop-transcriber.settings.json` を作成し、PaddleOCR 用 Python、worker script、OCR 設定を書き込む。
+7. 互換用の起動スクリプトを作成する。
+8. スタートメニューに `MovieTelopTranscriber.App.exe` 直起動のショートカットを作成する。
 
 ### 5.2 配置先を指定する
 
@@ -126,7 +129,7 @@ powershell -NoProfile -ExecutionPolicy Bypass `
   -SkipModelDownload
 ```
 
-この場合、実動画 OCR を使うには別途 `MOVIE_TELOP_PADDLEOCR_PYTHON` を設定する。
+この場合、実動画 OCR を使うには、`app\movie-telop-transcriber.settings.json` の `paddleOcr.pythonPath` を利用可能な Python へ合わせる。
 
 ### 5.6 事前確認
 実際の配置を行わず、インストール計画だけを確認する場合:
@@ -138,7 +141,9 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 ```
 
 ## 6. 起動
-インストーラを使った場合は、スタートメニューの `Movie Telop Transcriber` から起動する。
+インストーラを使った場合は、スタートメニューの `Movie Telop Transcriber`、または `app\MovieTelopTranscriber.App.exe` をダブルクリックして起動する。
+
+互換用に `Start-MovieTelopTranscriber.ps1` も生成されるが、通常利用では不要である。
 
 PowerShell から起動する場合:
 
@@ -147,19 +152,26 @@ powershell -NoProfile -ExecutionPolicy Bypass `
   -File "$env:LOCALAPPDATA\Programs\MovieTelopTranscriber\Start-MovieTelopTranscriber.ps1"
 ```
 
-起動スクリプトは次の環境変数を設定してからアプリを起動する。
+通常起動では、アプリは `app\movie-telop-transcriber.settings.json` を読み込んで次の設定を解決する。
 
-```powershell
-$env:MOVIE_TELOP_OCR_ENGINE = "paddleocr"
-$env:MOVIE_TELOP_PADDLEOCR_PYTHON = "<OcrRuntimeRoot>\.venv\Scripts\python.exe"
-$env:MOVIE_TELOP_PADDLEOCR_DEVICE = "cpu"
-$env:MOVIE_TELOP_PADDLEOCR_MIN_SCORE = "0.5"
-$env:MOVIE_TELOP_PADDLEOCR_PREPROCESS = "true"
-$env:MOVIE_TELOP_PADDLEOCR_CONTRAST = "1.1"
-$env:MOVIE_TELOP_PADDLEOCR_SHARPEN = "true"
+```json
+{
+  "ocrEngine": "paddleocr",
+  "paddleOcr": {
+    "pythonPath": "<OcrRuntimeRoot>\\.venv\\Scripts\\python.exe",
+    "scriptPath": "<InstallRoot>\\app\\tools\\ocr\\paddle_ocr_worker.py",
+    "device": "cpu",
+    "language": "ja",
+    "minScore": 0.5,
+    "normalizeSmallKana": true,
+    "preprocess": true,
+    "contrast": 1.1,
+    "sharpen": true
+  }
+}
 ```
 
-通常利用では `MOVIE_TELOP_OCR_ENGINE` を省略しても PaddleOCR が既定になる。ただし、利用する Python を明示するため、導入確認では `MOVIE_TELOP_PADDLEOCR_PYTHON` を必ず設定する。
+PowerShell 起動スクリプトを使う場合も、実際の OCR 解決元はこの設定ファイルである。
 
 ## 7. 初回確認
 1. アプリを起動する。
@@ -274,7 +286,7 @@ Start-Process `
 | `%LOCALAPPDATA%\Programs\MovieTelopTranscriber\ocr-runtime` | 起動スクリプト内の `MOVIE_TELOP_PADDLEOCR_PYTHON` と一致する場所 |
 | `%USERPROFILE%\.paddlex` | 対象端末の `%USERPROFILE%\.paddlex` |
 
-コピー後、対象端末で `Start-MovieTelopTranscriber.ps1` の `MOVIE_TELOP_PADDLEOCR_PYTHON` がコピー先の Python を指していることを確認する。
+コピー後、対象端末で `app\movie-telop-transcriber.settings.json` の `paddleOcr.pythonPath` がコピー先の Python を指していることを確認する。
 
 ## 10. サンプル sidecar 検証
 `json-sidecar` は開発・検証用の明示モードであり、実動画 OCR の標準手順では使わない。

--- a/docs/13_リリースノート.md
+++ b/docs/13_リリースノート.md
@@ -15,6 +15,7 @@
 - PowerShell インストーラ `Install-MovieTelopTranscriber.ps1` を追加した。
 - インストーラでアプリ本体の取得、所定ディレクトリへの配置、PaddleOCR 用 Python 仮想環境作成、PaddlePaddle / PaddleOCR package 導入、OCR モデル取得、起動スクリプト作成、スタートメニュー登録を行えるようにした。
 - インストーラが `movie-telop-transcriber.settings.json` を生成し、`MovieTelopTranscriber.App.exe` の直起動で OCR 設定を解決できるようにした。
+- `Uninstall-MovieTelopTranscriber.ps1` / `.cmd` を追加し、導入先フォルダ、導入先を指すユーザー環境変数、導入で新規取得したモデルを削除できるようにした。
 - PaddleOCR worker に `--warmup-models` を追加し、モデル取得を明示的に実行できるようにした。
 - 配布 zip 内にインストーラを同梱し、GitHub Release asset としてもインストーラ単体を公開する。
 
@@ -28,7 +29,7 @@ Install-MovieTelopTranscriber.ps1
 Install-MovieTelopTranscriber.ps1.sha256
 ```
 
-アプリ本体 zip には、WinUI 3 アプリの Release build 出力一式、`tools/ocr/paddle_ocr_worker.py`、`Install-MovieTelopTranscriber.ps1`、`Install-MovieTelopTranscriber.cmd`、利用者向けドキュメント、最小サンプルを含める。
+アプリ本体 zip には、WinUI 3 アプリの Release build 出力一式、`tools/ocr/paddle_ocr_worker.py`、`Install-MovieTelopTranscriber.ps1`、`Install-MovieTelopTranscriber.cmd`、`Uninstall-MovieTelopTranscriber.ps1`、`Uninstall-MovieTelopTranscriber.cmd`、利用者向けドキュメント、最小サンプルを含める。
 
 Python ランタイム、PaddlePaddle / PaddleOCR の Python package、PaddleOCR モデル本体はアプリ本体 zip には含めない。オンライン導入ではインストーラが利用者環境へ取得する。オフライン環境に持ち込む場合は、導入手順書に従って OCR runtime と `%USERPROFILE%\.paddlex` のモデルキャッシュを別途配置する。
 

--- a/docs/13_リリースノート.md
+++ b/docs/13_リリースノート.md
@@ -14,6 +14,7 @@
 - リポジトリルートの `README.md` を、利用者向けと開発者向けの二部構成に再構成した。
 - PowerShell インストーラ `Install-MovieTelopTranscriber.ps1` を追加した。
 - インストーラでアプリ本体の取得、所定ディレクトリへの配置、PaddleOCR 用 Python 仮想環境作成、PaddlePaddle / PaddleOCR package 導入、OCR モデル取得、起動スクリプト作成、スタートメニュー登録を行えるようにした。
+- インストーラが `movie-telop-transcriber.settings.json` を生成し、`MovieTelopTranscriber.App.exe` の直起動で OCR 設定を解決できるようにした。
 - PaddleOCR worker に `--warmup-models` を追加し、モデル取得を明示的に実行できるようにした。
 - 配布 zip 内にインストーラを同梱し、GitHub Release asset としてもインストーラ単体を公開する。
 
@@ -27,7 +28,7 @@ Install-MovieTelopTranscriber.ps1
 Install-MovieTelopTranscriber.ps1.sha256
 ```
 
-アプリ本体 zip には、WinUI 3 アプリの Release build 出力一式、`tools/ocr/paddle_ocr_worker.py`、`Install-MovieTelopTranscriber.ps1`、利用者向けドキュメント、最小サンプルを含める。
+アプリ本体 zip には、WinUI 3 アプリの Release build 出力一式、`tools/ocr/paddle_ocr_worker.py`、`Install-MovieTelopTranscriber.ps1`、`Install-MovieTelopTranscriber.cmd`、利用者向けドキュメント、最小サンプルを含める。
 
 Python ランタイム、PaddlePaddle / PaddleOCR の Python package、PaddleOCR モデル本体はアプリ本体 zip には含めない。オンライン導入ではインストーラが利用者環境へ取得する。オフライン環境に持ち込む場合は、導入手順書に従って OCR runtime と `%USERPROFILE%\.paddlex` のモデルキャッシュを別途配置する。
 
@@ -46,11 +47,11 @@ Python ランタイム、PaddlePaddle / PaddleOCR の Python package、PaddleOCR
 
 ### 5.2 インストーラ
 - インストーラのオンライン導入では、GitHub Release、PaddlePaddle wheel 配布元、PyPI、PaddleOCR モデル取得先へ接続できる必要がある。
-- Python 3.10 は事前に利用者環境へ導入されている前提である。既定では `py -3.10` を使う。
+- Python 3.10 は事前に利用者環境へ導入されている前提である。既定では `py -3.10` を使い、導入後は `movie-telop-transcriber.settings.json` に解決結果を書き込む。
 - プロキシや社内ネットワーク制限がある端末では、オフライン導入手順で OCR runtime と `.paddlex` を事前配置する。
 
 ### 5.3 OCR
-- PaddleOCR の Python 環境が未導入、または `MOVIE_TELOP_PADDLEOCR_PYTHON` が想定外の Python を指している場合、実動画 OCR は OCR エラーになる。
+- PaddleOCR の Python 環境が未導入、または `movie-telop-transcriber.settings.json` の `paddleOcr.pythonPath` が想定外の Python を指している場合、実動画 OCR は OCR エラーになる。
 - CPU 推論の処理時間は動画解像度、抽出間隔、検出しきい値、前処理設定、モデル配置状況により大きく変わる。
 - Windows OCR baseline worker は実装済みだが、日本語テロップの認識精度が不足したため、標準の実 OCR 経路としては PaddleOCR を推奨する。
 

--- a/docs/test-results/2026-04-29_issue122_exe_settings_launch.md
+++ b/docs/test-results/2026-04-29_issue122_exe_settings_launch.md
@@ -43,6 +43,14 @@
 - 導入後は `MovieTelopTranscriber.App.exe` をダブルクリックして起動できる。
 - OCR 実行時の設定解決は `settings.json` 側へ寄せられ、PowerShell 起動スクリプトは互換用の位置づけになった。
 
+## 5.1 追加: アンインストーラー確認
+| 項目 | コマンド / 方法 | 結果 |
+| --- | --- | --- |
+| 既定導入先確認 | 任意の親ディレクトリで `Install-MovieTelopTranscriber.ps1 -WhatIf` | 成功。`<親ディレクトリ>\MovieTelopTranscriber` 配下へ導入されることを確認 |
+| アンインストーラー配置 | 既定導入先へローカル導入 | 成功。`Uninstall-MovieTelopTranscriber.ps1` / `.cmd` と `movie-telop-transcriber.installation.json` を確認 |
+| 環境変数削除 | 導入先を指す `MOVIE_TELOP_PADDLEOCR_PYTHON`、`MOVIE_TELOP_PADDLEOCR_SCRIPT` をユーザー環境変数へ設定後、アンインストーラー実行 | 成功。両方とも削除を確認 |
+| 導入先削除 | `Uninstall-MovieTelopTranscriber.ps1` 実行後に導入先フォルダ消滅を確認 | 成功 |
+
 ## 6. 残課題
 - `SkipOcrSetup` 指定時は `pythonPath` が未生成の仮想環境を指すため、実動画 OCR 実行前に OCR runtime 導入が別途必要。
 - 将来的に利用者が設定画面から OCR runtime の場所を変更する要件が出る場合は、`settings.json` の再生成または GUI 編集機能を別 Issue で扱う。

--- a/docs/test-results/2026-04-29_issue122_exe_settings_launch.md
+++ b/docs/test-results/2026-04-29_issue122_exe_settings_launch.md
@@ -1,0 +1,48 @@
+# #122 EXE 直起動と settings.json 導入導線 実装検証
+
+## 1. 対象
+- Issue: `#122` ダブルクリックで導入開始と起動ができる入口を追加する
+- 実施日: 2026-04-29
+- 実施者: Codex
+
+## 2. 実装概要
+- 起動時に `app\movie-telop-transcriber.settings.json` を読み込み、OCR engine、PaddleOCR 用 Python、worker script、主要 OCR 設定を反映する層を追加した。
+- インストーラは `movie-telop-transcriber.settings.json` を生成し、スタートメニューは `MovieTelopTranscriber.App.exe` 直起動へ寄せた。
+- 配布物には `Install-MovieTelopTranscriber.cmd` を同梱し、利用者が PowerShell コマンドを手入力しなくても導入を開始できるようにした。
+
+## 3. 確認項目
+| 項目 | コマンド / 方法 | 結果 |
+| --- | --- | --- |
+| Release build | `dotnet build src\MovieTelopTranscriber.sln -c Release -p:Platform=x64` | 成功 |
+| インストーラ計画確認 | `Install-MovieTelopTranscriber.ps1 -WhatIf` | 成功。`AppSettingsPath` が出力されることを確認 |
+| 配布物再生成 | `tools\release\New-ReleasePackage.ps1 -Version 0.1.1 -SkipBuild` | 成功。zip を再生成 |
+| ローカル導入 | `Install-MovieTelopTranscriber.ps1 -PackageZipPath ... -InstallRoot ... -OcrRuntimeRoot ... -SkipOcrSetup -SkipModelDownload -NoStartMenuShortcut -Force` | 成功。`movie-telop-transcriber.settings.json` を生成 |
+| 設定ファイル内容 | `Get-Content app\movie-telop-transcriber.settings.json` | 成功。`ocrEngine=paddleocr`、`pythonPath`、`scriptPath`、`device=cpu`、前処理設定を確認 |
+| EXE 直起動 | 導入先 `app\MovieTelopTranscriber.App.exe` を起動し 5 秒後にプロセス生存確認 | 成功。起動直後に異常終了しないことを確認 |
+
+## 4. 生成された設定ファイル例
+```json
+{
+  "ocrEngine": "paddleocr",
+  "paddleOcr": {
+    "pythonPath": "<InstallRoot>\\..\\ocr-runtime\\.venv\\Scripts\\python.exe",
+    "scriptPath": "<InstallRoot>\\app\\tools\\ocr\\paddle_ocr_worker.py",
+    "device": "cpu",
+    "language": "ja",
+    "minScore": 0.5,
+    "normalizeSmallKana": true,
+    "preprocess": true,
+    "contrast": 1.1,
+    "sharpen": true
+  }
+}
+```
+
+## 5. 判断
+- 利用者は配布物の `Install-MovieTelopTranscriber.cmd` から導入を開始できる。
+- 導入後は `MovieTelopTranscriber.App.exe` をダブルクリックして起動できる。
+- OCR 実行時の設定解決は `settings.json` 側へ寄せられ、PowerShell 起動スクリプトは互換用の位置づけになった。
+
+## 6. 残課題
+- `SkipOcrSetup` 指定時は `pythonPath` が未生成の仮想環境を指すため、実動画 OCR 実行前に OCR runtime 導入が別途必要。
+- 将来的に利用者が設定画面から OCR runtime の場所を変更する要件が出る場合は、`settings.json` の再生成または GUI 編集機能を別 Issue で扱う。

--- a/src/MovieTelopTranscriber.App/App.xaml.cs
+++ b/src/MovieTelopTranscriber.App/App.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
+using MovieTelopTranscriber.App.Services;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -42,6 +43,7 @@ public partial class App : Application
     public App()
     {
         InitializeComponent();
+        AppLaunchSettingsLoader.Apply();
     }
 
     /// <summary>

--- a/src/MovieTelopTranscriber.App/Models/AppLaunchSettings.cs
+++ b/src/MovieTelopTranscriber.App/Models/AppLaunchSettings.cs
@@ -1,0 +1,43 @@
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed class AppLaunchSettings
+{
+    public string? OcrEngine { get; set; }
+
+    public string? OcrWorkerPath { get; set; }
+
+    public PaddleOcrLaunchSettings? PaddleOcr { get; set; }
+}
+
+public sealed class PaddleOcrLaunchSettings
+{
+    public string? PythonPath { get; set; }
+
+    public string? ScriptPath { get; set; }
+
+    public string? Device { get; set; }
+
+    public string? Language { get; set; }
+
+    public double? MinScore { get; set; }
+
+    public bool? NormalizeSmallKana { get; set; }
+
+    public bool? Preprocess { get; set; }
+
+    public double? Contrast { get; set; }
+
+    public bool? Sharpen { get; set; }
+
+    public double? TextDetThresh { get; set; }
+
+    public double? TextDetBoxThresh { get; set; }
+
+    public double? TextDetUnclipRatio { get; set; }
+
+    public int? TextDetLimitSideLen { get; set; }
+
+    public bool? UseTextlineOrientation { get; set; }
+
+    public bool? UseDocUnwarping { get; set; }
+}

--- a/src/MovieTelopTranscriber.App/Services/AppLaunchSettingsLoader.cs
+++ b/src/MovieTelopTranscriber.App/Services/AppLaunchSettingsLoader.cs
@@ -1,0 +1,233 @@
+using System.Globalization;
+using System.Text.Json;
+using MovieTelopTranscriber.App.Models;
+
+namespace MovieTelopTranscriber.App.Services;
+
+internal static class AppLaunchSettingsLoader
+{
+    private const string SettingsFileName = "movie-telop-transcriber.settings.json";
+
+    public static void Apply()
+    {
+        var settingsPath = Path.Combine(AppContext.BaseDirectory, SettingsFileName);
+        if (!File.Exists(settingsPath))
+        {
+            return;
+        }
+
+        AppLaunchSettings? settings;
+        try
+        {
+            using var stream = File.OpenRead(settingsPath);
+            using var document = JsonDocument.Parse(stream);
+            settings = ParseSettings(document.RootElement);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            Environment.SetEnvironmentVariable(
+                "MOVIE_TELOP_LAUNCH_SETTINGS_LOAD_ERROR",
+                $"{settingsPath}: {ex.Message}");
+            return;
+        }
+
+        if (settings is null)
+        {
+            return;
+        }
+
+        SetString("MOVIE_TELOP_OCR_ENGINE", settings.OcrEngine);
+        SetPath("MOVIE_TELOP_OCR_WORKER", settings.OcrWorkerPath, settingsPath);
+
+        if (settings.PaddleOcr is null)
+        {
+            return;
+        }
+
+        SetPath("MOVIE_TELOP_PADDLEOCR_PYTHON", settings.PaddleOcr.PythonPath, settingsPath);
+        SetPath("MOVIE_TELOP_PADDLEOCR_SCRIPT", settings.PaddleOcr.ScriptPath, settingsPath);
+        SetString("MOVIE_TELOP_PADDLEOCR_DEVICE", settings.PaddleOcr.Device);
+        SetString("MOVIE_TELOP_PADDLEOCR_LANG", settings.PaddleOcr.Language);
+        SetDouble("MOVIE_TELOP_PADDLEOCR_MIN_SCORE", settings.PaddleOcr.MinScore);
+        SetBool("MOVIE_TELOP_PADDLEOCR_NORMALIZE_SMALL_KANA", settings.PaddleOcr.NormalizeSmallKana);
+        SetBool("MOVIE_TELOP_PADDLEOCR_PREPROCESS", settings.PaddleOcr.Preprocess);
+        SetDouble("MOVIE_TELOP_PADDLEOCR_CONTRAST", settings.PaddleOcr.Contrast);
+        SetBool("MOVIE_TELOP_PADDLEOCR_SHARPEN", settings.PaddleOcr.Sharpen);
+        SetDouble("MOVIE_TELOP_PADDLEOCR_TEXT_DET_THRESH", settings.PaddleOcr.TextDetThresh);
+        SetDouble("MOVIE_TELOP_PADDLEOCR_TEXT_DET_BOX_THRESH", settings.PaddleOcr.TextDetBoxThresh);
+        SetDouble("MOVIE_TELOP_PADDLEOCR_TEXT_DET_UNCLIP_RATIO", settings.PaddleOcr.TextDetUnclipRatio);
+        SetInt("MOVIE_TELOP_PADDLEOCR_TEXT_DET_LIMIT_SIDE_LEN", settings.PaddleOcr.TextDetLimitSideLen);
+        SetBool("MOVIE_TELOP_PADDLEOCR_USE_TEXTLINE_ORIENTATION", settings.PaddleOcr.UseTextlineOrientation);
+        SetBool("MOVIE_TELOP_PADDLEOCR_USE_DOC_UNWARPING", settings.PaddleOcr.UseDocUnwarping);
+    }
+
+    private static void SetPath(string environmentVariable, string? value, string settingsPath)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        var resolved = ResolvePath(value, settingsPath);
+        Environment.SetEnvironmentVariable(environmentVariable, resolved);
+    }
+
+    private static void SetString(string environmentVariable, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        Environment.SetEnvironmentVariable(environmentVariable, value);
+    }
+
+    private static void SetBool(string environmentVariable, bool? value)
+    {
+        if (!value.HasValue)
+        {
+            return;
+        }
+
+        Environment.SetEnvironmentVariable(environmentVariable, value.Value ? "true" : "false");
+    }
+
+    private static void SetDouble(string environmentVariable, double? value)
+    {
+        if (!value.HasValue)
+        {
+            return;
+        }
+
+        Environment.SetEnvironmentVariable(
+            environmentVariable,
+            value.Value.ToString(CultureInfo.InvariantCulture));
+    }
+
+    private static void SetInt(string environmentVariable, int? value)
+    {
+        if (!value.HasValue)
+        {
+            return;
+        }
+
+        Environment.SetEnvironmentVariable(
+            environmentVariable,
+            value.Value.ToString(CultureInfo.InvariantCulture));
+    }
+
+    private static string ResolvePath(string value, string settingsPath)
+    {
+        var expanded = Environment.ExpandEnvironmentVariables(value);
+        if (Path.IsPathRooted(expanded))
+        {
+            return Path.GetFullPath(expanded);
+        }
+
+        var settingsDirectory = Path.GetDirectoryName(settingsPath) ?? AppContext.BaseDirectory;
+        return Path.GetFullPath(Path.Combine(settingsDirectory, expanded));
+    }
+
+    private static AppLaunchSettings ParseSettings(JsonElement root)
+    {
+        return new AppLaunchSettings
+        {
+            OcrEngine = ReadString(root, "ocrEngine"),
+            OcrWorkerPath = ReadString(root, "ocrWorkerPath"),
+            PaddleOcr = ReadObject(root, "paddleOcr") is { } paddle
+                ? new PaddleOcrLaunchSettings
+                {
+                    PythonPath = ReadString(paddle, "pythonPath"),
+                    ScriptPath = ReadString(paddle, "scriptPath"),
+                    Device = ReadString(paddle, "device"),
+                    Language = ReadString(paddle, "language"),
+                    MinScore = ReadDouble(paddle, "minScore"),
+                    NormalizeSmallKana = ReadBool(paddle, "normalizeSmallKana"),
+                    Preprocess = ReadBool(paddle, "preprocess"),
+                    Contrast = ReadDouble(paddle, "contrast"),
+                    Sharpen = ReadBool(paddle, "sharpen"),
+                    TextDetThresh = ReadDouble(paddle, "textDetThresh"),
+                    TextDetBoxThresh = ReadDouble(paddle, "textDetBoxThresh"),
+                    TextDetUnclipRatio = ReadDouble(paddle, "textDetUnclipRatio"),
+                    TextDetLimitSideLen = ReadInt(paddle, "textDetLimitSideLen"),
+                    UseTextlineOrientation = ReadBool(paddle, "useTextlineOrientation"),
+                    UseDocUnwarping = ReadBool(paddle, "useDocUnwarping")
+                }
+                : null
+        };
+    }
+
+    private static JsonElement? ReadObject(JsonElement element, string propertyName)
+    {
+        if (!TryGetProperty(element, propertyName, out var property))
+        {
+            return null;
+        }
+
+        return property.ValueKind == JsonValueKind.Object ? property : null;
+    }
+
+    private static string? ReadString(JsonElement element, string propertyName)
+    {
+        if (!TryGetProperty(element, propertyName, out var property))
+        {
+            return null;
+        }
+
+        return property.ValueKind == JsonValueKind.String ? property.GetString() : null;
+    }
+
+    private static bool? ReadBool(JsonElement element, string propertyName)
+    {
+        if (!TryGetProperty(element, propertyName, out var property))
+        {
+            return null;
+        }
+
+        return property.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => null
+        };
+    }
+
+    private static double? ReadDouble(JsonElement element, string propertyName)
+    {
+        if (!TryGetProperty(element, propertyName, out var property))
+        {
+            return null;
+        }
+
+        return property.ValueKind == JsonValueKind.Number && property.TryGetDouble(out var value)
+            ? value
+            : null;
+    }
+
+    private static int? ReadInt(JsonElement element, string propertyName)
+    {
+        if (!TryGetProperty(element, propertyName, out var property))
+        {
+            return null;
+        }
+
+        return property.ValueKind == JsonValueKind.Number && property.TryGetInt32(out var value)
+            ? value
+            : null;
+    }
+
+    private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement value)
+    {
+        foreach (var property in element.EnumerateObject())
+        {
+            if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/src/MovieTelopTranscriber.App/Services/ProcessOcrWorkerClient.cs
+++ b/src/MovieTelopTranscriber.App/Services/ProcessOcrWorkerClient.cs
@@ -53,7 +53,7 @@ public sealed class ProcessOcrWorkerClient : IOcrWorkerClient
             request,
             "OCR_SIDECAR_NOT_FOUND",
             "No OCR worker is configured and no sidecar OCR response exists for this frame.",
-            $"Set {EngineEnvironmentVariable}=paddleocr for real-video OCR, configure {WorkerPathEnvironmentVariable}, or provide sidecar file: {sidecarPath}",
+            $"Set {EngineEnvironmentVariable}=paddleocr, configure {WorkerPathEnvironmentVariable}, provide movie-telop-transcriber.settings.json, or provide sidecar file: {sidecarPath}",
             true);
         await WriteJsonAsync(responsePath, missingSidecarResponse, cancellationToken);
         return missingSidecarResponse;

--- a/tools/install/Install-MovieTelopTranscriber.cmd
+++ b/tools/install/Install-MovieTelopTranscriber.cmd
@@ -1,0 +1,37 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "PACKAGE_SCRIPT=%SCRIPT_DIR%Install-MovieTelopTranscriber.ps1"
+set "REPO_SCRIPT=%SCRIPT_DIR%tools\install\Install-MovieTelopTranscriber.ps1"
+set "PS_SCRIPT="
+
+if exist "%PACKAGE_SCRIPT%" set "PS_SCRIPT=%PACKAGE_SCRIPT%"
+if not defined PS_SCRIPT if exist "%REPO_SCRIPT%" set "PS_SCRIPT=%REPO_SCRIPT%"
+
+if not defined PS_SCRIPT (
+  echo Install-MovieTelopTranscriber.ps1 was not found.
+  echo Place this command file next to the packaged installer or keep it under tools\install in the repository.
+  pause
+  exit /b 1
+)
+
+set "INTERACTIVE="
+if "%~1"=="" set "INTERACTIVE=1"
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%PS_SCRIPT%" %*
+set "EXITCODE=%ERRORLEVEL%"
+
+if not "%EXITCODE%"=="0" (
+  echo Installation failed. Exit code: %EXITCODE%
+  pause
+  exit /b %EXITCODE%
+)
+
+if defined INTERACTIVE (
+  echo Installation completed.
+  echo Use "Movie Telop Transcriber.cmd" in the install folder or the Start menu shortcut to launch the app.
+  pause
+)
+
+exit /b 0

--- a/tools/install/Install-MovieTelopTranscriber.ps1
+++ b/tools/install/Install-MovieTelopTranscriber.ps1
@@ -33,9 +33,11 @@ $downloadZipPath = Join-Path $DownloadRoot "$packageName.zip"
 $expandedRoot = Join-Path $DownloadRoot "expanded"
 $appDir = Join-Path $InstallRoot "app"
 $appExe = Join-Path $appDir "MovieTelopTranscriber.App.exe"
+$appSettingsPath = Join-Path $appDir "movie-telop-transcriber.settings.json"
 $venvDir = Join-Path $OcrRuntimeRoot ".venv"
 $venvPython = Join-Path $venvDir "Scripts\python.exe"
 $launcherPath = Join-Path $InstallRoot "Start-MovieTelopTranscriber.ps1"
+$launcherCommandPath = Join-Path $InstallRoot "Movie Telop Transcriber.cmd"
 $modelRoot = Join-Path $env:USERPROFILE ".paddlex\official_models"
 $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoWorkerPath = Join-Path $scriptRoot "..\ocr\paddle_ocr_worker.py"
@@ -107,19 +109,48 @@ function Write-Launcher {
 `$ErrorActionPreference = "Stop"
 `$InstallRoot = Split-Path -Parent `$MyInvocation.MyCommand.Path
 `$AppDir = Join-Path `$InstallRoot "app"
-
-`$env:MOVIE_TELOP_OCR_ENGINE = "paddleocr"
-`$env:MOVIE_TELOP_PADDLEOCR_PYTHON = "$venvPython"
-`$env:MOVIE_TELOP_PADDLEOCR_DEVICE = "cpu"
-`$env:MOVIE_TELOP_PADDLEOCR_MIN_SCORE = "0.5"
-`$env:MOVIE_TELOP_PADDLEOCR_PREPROCESS = "true"
-`$env:MOVIE_TELOP_PADDLEOCR_CONTRAST = "1.1"
-`$env:MOVIE_TELOP_PADDLEOCR_SHARPEN = "true"
-
 Start-Process -FilePath (Join-Path `$AppDir "MovieTelopTranscriber.App.exe") -WorkingDirectory `$AppDir
 "@
 
     [System.IO.File]::WriteAllText($launcherPath, $launcherContent, [System.Text.UTF8Encoding]::new($false))
+}
+
+function Write-LauncherCommand {
+    $launcherCommandContent = @"
+@echo off
+setlocal
+set "APP_DIR=%~dp0app"
+"%APP_DIR%\MovieTelopTranscriber.App.exe" %*
+set "EXITCODE=%ERRORLEVEL%"
+if not "%EXITCODE%"=="0" (
+  echo Movie Telop Transcriber failed to start. Exit code: %EXITCODE%
+  pause
+)
+exit /b %EXITCODE%
+"@
+
+    [System.IO.File]::WriteAllText($launcherCommandPath, $launcherCommandContent, [System.Text.ASCIIEncoding]::new())
+}
+
+function Write-AppLaunchSettings {
+    $scriptPath = Resolve-WorkerPath
+    $settingsObject = [ordered]@{
+        ocrEngine = "paddleocr"
+        paddleOcr = [ordered]@{
+            pythonPath = $venvPython
+            scriptPath = $scriptPath
+            device = "cpu"
+            language = "ja"
+            minScore = 0.5
+            normalizeSmallKana = $true
+            preprocess = $true
+            contrast = 1.1
+            sharpen = $true
+        }
+    }
+
+    $json = $settingsObject | ConvertTo-Json -Depth 5
+    [System.IO.File]::WriteAllText($appSettingsPath, $json, [System.Text.UTF8Encoding]::new($false))
 }
 
 function New-StartMenuShortcut {
@@ -129,9 +160,9 @@ function New-StartMenuShortcut {
     $shortcutPath = Join-Path $shortcutDirectory "Movie Telop Transcriber.lnk"
     $shell = New-Object -ComObject WScript.Shell
     $shortcut = $shell.CreateShortcut($shortcutPath)
-    $shortcut.TargetPath = "powershell.exe"
-    $shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$launcherPath`""
-    $shortcut.WorkingDirectory = $InstallRoot
+    $shortcut.TargetPath = $appExe
+    $shortcut.Arguments = ""
+    $shortcut.WorkingDirectory = $appDir
     $shortcut.IconLocation = "$appExe,0"
     $shortcut.Save()
 }
@@ -163,6 +194,8 @@ if ($WhatIfPreference) {
         SkipOcrSetup = [bool]$SkipOcrSetup
         SkipModelDownload = [bool]$SkipModelDownload
         LauncherPath = $launcherPath
+        LauncherCommandPath = $launcherCommandPath
+        AppSettingsPath = $appSettingsPath
     }
     return
 }
@@ -274,6 +307,16 @@ if ($PSCmdlet.ShouldProcess($launcherPath, "Write launcher")) {
     Write-Launcher
 }
 
+Write-InstallLog "Writing launcher command: $launcherCommandPath"
+if ($PSCmdlet.ShouldProcess($launcherCommandPath, "Write launcher command")) {
+    Write-LauncherCommand
+}
+
+Write-InstallLog "Writing app launch settings: $appSettingsPath"
+if ($PSCmdlet.ShouldProcess($appSettingsPath, "Write app launch settings")) {
+    Write-AppLaunchSettings
+}
+
 if (-not $NoStartMenuShortcut) {
     Write-InstallLog "Creating Start Menu shortcut"
     if ($PSCmdlet.ShouldProcess("Start Menu", "Create shortcut")) {
@@ -292,7 +335,9 @@ if ($Launch) {
     Version = $Version
     InstallRoot = $InstallRoot
     AppExe = $appExe
+    AppSettingsPath = $appSettingsPath
     LauncherPath = $launcherPath
+    LauncherCommandPath = $launcherCommandPath
     OcrRuntimeRoot = $OcrRuntimeRoot
     PaddleOcrPython = $venvPython
     ModelRoot = $modelRoot

--- a/tools/install/Install-MovieTelopTranscriber.ps1
+++ b/tools/install/Install-MovieTelopTranscriber.ps1
@@ -1,8 +1,8 @@
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
     [string]$Version = "0.1.1",
-    [string]$InstallRoot = (Join-Path $env:LOCALAPPDATA "Programs\MovieTelopTranscriber"),
-    [string]$OcrRuntimeRoot = (Join-Path $env:LOCALAPPDATA "Programs\MovieTelopTranscriber\ocr-runtime"),
+    [string]$InstallRoot,
+    [string]$OcrRuntimeRoot,
     [string]$DownloadRoot = (Join-Path $env:TEMP "movie-telop-transcriber-install"),
     [string]$PackageZipPath,
     [string]$ReleaseAssetUrl,
@@ -26,7 +26,15 @@ if ([string]::IsNullOrWhiteSpace($ReleaseAssetUrl)) {
     $ReleaseAssetUrl = "https://github.com/$repository/releases/download/v$Version/$packageName.zip"
 }
 
+$defaultInstallRoot = Join-Path (Get-Location).Path "MovieTelopTranscriber"
+if ([string]::IsNullOrWhiteSpace($InstallRoot)) {
+    $InstallRoot = $defaultInstallRoot
+}
+
 $InstallRoot = [System.IO.Path]::GetFullPath($InstallRoot)
+if ([string]::IsNullOrWhiteSpace($OcrRuntimeRoot)) {
+    $OcrRuntimeRoot = Join-Path $InstallRoot "ocr-runtime"
+}
 $OcrRuntimeRoot = [System.IO.Path]::GetFullPath($OcrRuntimeRoot)
 $DownloadRoot = [System.IO.Path]::GetFullPath($DownloadRoot)
 $downloadZipPath = Join-Path $DownloadRoot "$packageName.zip"

--- a/tools/install/Install-MovieTelopTranscriber.ps1
+++ b/tools/install/Install-MovieTelopTranscriber.ps1
@@ -46,7 +46,17 @@ $venvDir = Join-Path $OcrRuntimeRoot ".venv"
 $venvPython = Join-Path $venvDir "Scripts\python.exe"
 $launcherPath = Join-Path $InstallRoot "Start-MovieTelopTranscriber.ps1"
 $launcherCommandPath = Join-Path $InstallRoot "Movie Telop Transcriber.cmd"
+$uninstallerPath = Join-Path $InstallRoot "Uninstall-MovieTelopTranscriber.ps1"
+$uninstallerCommandPath = Join-Path $InstallRoot "Uninstall-MovieTelopTranscriber.cmd"
+$installManifestPath = Join-Path $InstallRoot "movie-telop-transcriber.installation.json"
 $modelRoot = Join-Path $env:USERPROFILE ".paddlex\official_models"
+$startMenuShortcutDirectory = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Movie Telop Transcriber"
+$startMenuShortcutPath = Join-Path $startMenuShortcutDirectory "Movie Telop Transcriber.lnk"
+$knownModelNames = @(
+    "PP-OCRv5_server_det",
+    "PP-OCRv5_server_rec"
+)
+$createdModelDirectories = @()
 $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoWorkerPath = Join-Path $scriptRoot "..\ocr\paddle_ocr_worker.py"
 $installedWorkerPath = Join-Path $appDir "tools\ocr\paddle_ocr_worker.py"
@@ -161,13 +171,38 @@ function Write-AppLaunchSettings {
     [System.IO.File]::WriteAllText($appSettingsPath, $json, [System.Text.UTF8Encoding]::new($false))
 }
 
-function New-StartMenuShortcut {
-    $shortcutDirectory = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Movie Telop Transcriber"
-    New-Item -ItemType Directory -Path $shortcutDirectory -Force | Out-Null
+function Write-InstallManifest {
+    $manifestObject = [ordered]@{
+        version = $Version
+        installRoot = $InstallRoot
+        ocrRuntimeRoot = $OcrRuntimeRoot
+        appExe = $appExe
+        appSettingsPath = $appSettingsPath
+        launcherPath = $launcherPath
+        launcherCommandPath = $launcherCommandPath
+        uninstallerPath = $uninstallerPath
+        uninstallerCommandPath = $uninstallerCommandPath
+        startMenuShortcutDirectory = $startMenuShortcutDirectory
+        startMenuShortcutPath = $startMenuShortcutPath
+        modelRoot = $modelRoot
+        createdModelDirectories = $createdModelDirectories
+        legacyUserEnvironmentVariables = @(
+            "MOVIE_TELOP_OCR_WORKER",
+            "MOVIE_TELOP_PADDLEOCR_PYTHON",
+            "MOVIE_TELOP_PADDLEOCR_SCRIPT"
+        )
+        persistentEnvironmentVariables = @()
+    }
 
-    $shortcutPath = Join-Path $shortcutDirectory "Movie Telop Transcriber.lnk"
+    $json = $manifestObject | ConvertTo-Json -Depth 5
+    [System.IO.File]::WriteAllText($installManifestPath, $json, [System.Text.UTF8Encoding]::new($false))
+}
+
+function New-StartMenuShortcut {
+    New-Item -ItemType Directory -Path $startMenuShortcutDirectory -Force | Out-Null
+
     $shell = New-Object -ComObject WScript.Shell
-    $shortcut = $shell.CreateShortcut($shortcutPath)
+    $shortcut = $shell.CreateShortcut($startMenuShortcutPath)
     $shortcut.TargetPath = $appExe
     $shortcut.Arguments = ""
     $shortcut.WorkingDirectory = $appDir
@@ -204,6 +239,9 @@ if ($WhatIfPreference) {
         LauncherPath = $launcherPath
         LauncherCommandPath = $launcherCommandPath
         AppSettingsPath = $appSettingsPath
+        UninstallerPath = $uninstallerPath
+        UninstallerCommandPath = $uninstallerCommandPath
+        InstallManifestPath = $installManifestPath
     }
     return
 }
@@ -284,17 +322,26 @@ if (-not $SkipOcrSetup) {
         $workerPath = Resolve-WorkerPath
         $env:MOVIE_TELOP_PADDLEOCR_DEVICE = "cpu"
         $env:MOVIE_TELOP_PADDLEOCR_PREPROCESS = "false"
+        $existingModelDirectories = @(
+            $knownModelNames |
+            Where-Object { Test-Path -LiteralPath (Join-Path $modelRoot $_) } |
+            ForEach-Object { Join-Path $modelRoot $_ }
+        )
 
         Write-InstallLog "Downloading and warming PaddleOCR models"
         if ($PSCmdlet.ShouldProcess($modelRoot, "Warm up PaddleOCR models")) {
             Invoke-CheckedCommand -FilePath $venvPython -Arguments @($workerPath, "--warmup-models", "--warmup-language", "ja")
         }
 
-        $knownModels = @(
-            "PP-OCRv5_server_det",
-            "PP-OCRv5_server_rec"
+        $createdModelDirectories = @(
+            $knownModelNames |
+            ForEach-Object { Join-Path $modelRoot $_ } |
+            Where-Object {
+                (Test-Path -LiteralPath $_) -and ($_ -notin $existingModelDirectories)
+            }
         )
-        $missingModels = @($knownModels | Where-Object { -not (Test-Path -LiteralPath (Join-Path $modelRoot $_)) })
+
+        $missingModels = @($knownModelNames | Where-Object { -not (Test-Path -LiteralPath (Join-Path $modelRoot $_)) })
         if ($missingModels.Count -gt 0) {
             Write-Warning ("PaddleOCR model folders were not found at the expected path: {0}" -f ($missingModels -join ", "))
             Write-Warning "The models may have been stored in a PaddleOCR-specific cache path. Check the warmup output above if OCR fails."
@@ -325,6 +372,11 @@ if ($PSCmdlet.ShouldProcess($appSettingsPath, "Write app launch settings")) {
     Write-AppLaunchSettings
 }
 
+Write-InstallLog "Writing install manifest: $installManifestPath"
+if ($PSCmdlet.ShouldProcess($installManifestPath, "Write install manifest")) {
+    Write-InstallManifest
+}
+
 if (-not $NoStartMenuShortcut) {
     Write-InstallLog "Creating Start Menu shortcut"
     if ($PSCmdlet.ShouldProcess("Start Menu", "Create shortcut")) {
@@ -346,7 +398,11 @@ if ($Launch) {
     AppSettingsPath = $appSettingsPath
     LauncherPath = $launcherPath
     LauncherCommandPath = $launcherCommandPath
+    UninstallerPath = $uninstallerPath
+    UninstallerCommandPath = $uninstallerCommandPath
+    InstallManifestPath = $installManifestPath
     OcrRuntimeRoot = $OcrRuntimeRoot
     PaddleOcrPython = $venvPython
     ModelRoot = $modelRoot
+    CreatedModelDirectories = $createdModelDirectories
 }

--- a/tools/install/Uninstall-MovieTelopTranscriber.cmd
+++ b/tools/install/Uninstall-MovieTelopTranscriber.cmd
@@ -1,0 +1,19 @@
+@echo off
+setlocal
+set "SCRIPT_DIR=%~dp0"
+set "PS_SCRIPT=%SCRIPT_DIR%Uninstall-MovieTelopTranscriber.ps1"
+
+if not exist "%PS_SCRIPT%" (
+  echo Uninstall-MovieTelopTranscriber.ps1 was not found.
+  pause
+  exit /b 1
+)
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%PS_SCRIPT%" %*
+set "EXITCODE=%ERRORLEVEL%"
+if not "%EXITCODE%"=="0" (
+  echo Uninstall failed. Exit code: %EXITCODE%
+  pause
+)
+exit /b %EXITCODE%
+

--- a/tools/install/Uninstall-MovieTelopTranscriber.ps1
+++ b/tools/install/Uninstall-MovieTelopTranscriber.ps1
@@ -1,0 +1,208 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [string]$InstallRoot,
+    [switch]$RemoveSharedModelCache
+)
+
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+
+if ([string]::IsNullOrWhiteSpace($InstallRoot)) {
+    $InstallRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+}
+
+$InstallRoot = [System.IO.Path]::GetFullPath($InstallRoot)
+$manifestPath = Join-Path $InstallRoot "movie-telop-transcriber.installation.json"
+$appDir = Join-Path $InstallRoot "app"
+$appExe = Join-Path $appDir "MovieTelopTranscriber.App.exe"
+$defaultOcrRuntimeRoot = Join-Path $InstallRoot "ocr-runtime"
+$defaultShortcutDirectory = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Movie Telop Transcriber"
+$defaultShortcutPath = Join-Path $defaultShortcutDirectory "Movie Telop Transcriber.lnk"
+$legacyUserEnvironmentVariables = @(
+    "MOVIE_TELOP_OCR_WORKER",
+    "MOVIE_TELOP_PADDLEOCR_PYTHON",
+    "MOVIE_TELOP_PADDLEOCR_SCRIPT"
+)
+
+function Get-UninstallManifest {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $null
+    }
+
+    try {
+        return Get-Content -LiteralPath $Path -Raw -Encoding utf8 | ConvertFrom-Json
+    } catch {
+        Write-Warning "Installation manifest could not be read: $Path"
+        return $null
+    }
+}
+
+function Remove-UserEnvironmentVariableIfOwned {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [string[]]$OwnedRoots = @()
+    )
+
+    $value = [Environment]::GetEnvironmentVariable($Name, "User")
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return $false
+    }
+
+    foreach ($root in $OwnedRoots) {
+        if ([string]::IsNullOrWhiteSpace($root)) {
+            continue
+        }
+
+        $expandedValue = [Environment]::ExpandEnvironmentVariables($value)
+        if (-not [System.IO.Path]::IsPathRooted($expandedValue)) {
+            continue
+        }
+
+        $normalizedValue = [System.IO.Path]::GetFullPath($expandedValue)
+        $normalizedRoot = [System.IO.Path]::GetFullPath($root).TrimEnd('\') + '\'
+        if ($normalizedValue.StartsWith($normalizedRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+            if ($PSCmdlet.ShouldProcess("User environment variable $Name", "Remove")) {
+                [Environment]::SetEnvironmentVariable($Name, $null, "User")
+            }
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Stop-InstalledProcesses {
+    param([string]$ExpectedExePath)
+
+    $expected = [System.IO.Path]::GetFullPath($ExpectedExePath)
+    Get-Process MovieTelopTranscriber.App -ErrorAction SilentlyContinue | ForEach-Object {
+        try {
+            $processPath = $_.Path
+        } catch {
+            $processPath = $null
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($processPath) -and
+            [string]::Equals([System.IO.Path]::GetFullPath($processPath), $expected, [System.StringComparison]::OrdinalIgnoreCase)) {
+            if ($PSCmdlet.ShouldProcess("Process $($_.Id)", "Stop")) {
+                Stop-Process -Id $_.Id -Force
+            }
+        }
+    }
+}
+
+function Start-CleanupScript {
+    param(
+        [string]$TargetInstallRoot,
+        [string]$ShortcutDirectory,
+        [string]$ShortcutPath
+    )
+
+    $cleanupScriptPath = Join-Path $env:TEMP ("movie-telop-transcriber-uninstall-" + [guid]::NewGuid().ToString("N") + ".cmd")
+    $cleanupContent = @"
+@echo off
+setlocal
+set "TARGET_ROOT=$TargetInstallRoot"
+set "SHORTCUT_DIRECTORY=$ShortcutDirectory"
+set "SHORTCUT_PATH=$ShortcutPath"
+for /L %%I in (1,1,20) do (
+  if exist "%TARGET_ROOT%" (
+    rmdir /S /Q "%TARGET_ROOT%" >nul 2>nul
+  )
+  if not exist "%TARGET_ROOT%" goto :root_removed
+  timeout /t 1 /nobreak >nul
+)
+:root_removed
+if exist "%SHORTCUT_PATH%" del /F /Q "%SHORTCUT_PATH%" >nul 2>nul
+if exist "%SHORTCUT_DIRECTORY%" rmdir /Q "%SHORTCUT_DIRECTORY%" >nul 2>nul
+del /F /Q "%~f0" >nul 2>nul
+"@
+
+    [System.IO.File]::WriteAllText($cleanupScriptPath, $cleanupContent, [System.Text.ASCIIEncoding]::new())
+    Start-Process -FilePath "cmd.exe" -ArgumentList "/c `"$cleanupScriptPath`"" -WindowStyle Hidden
+}
+
+$manifest = Get-UninstallManifest -Path $manifestPath
+$ocrRuntimeRoot = if ($manifest -and $manifest.ocrRuntimeRoot) { [string]$manifest.ocrRuntimeRoot } else { $defaultOcrRuntimeRoot }
+$shortcutDirectory = if ($manifest -and $manifest.startMenuShortcutDirectory) { [string]$manifest.startMenuShortcutDirectory } else { $defaultShortcutDirectory }
+$shortcutPath = if ($manifest -and $manifest.startMenuShortcutPath) { [string]$manifest.startMenuShortcutPath } else { $defaultShortcutPath }
+$createdModelDirectories = @()
+if ($manifest -and $manifest.createdModelDirectories) {
+    $createdModelDirectories = @($manifest.createdModelDirectories | ForEach-Object { [string]$_ })
+}
+$persistentEnvironmentVariables = @()
+if ($manifest -and $manifest.persistentEnvironmentVariables) {
+    $persistentEnvironmentVariables = @($manifest.persistentEnvironmentVariables | ForEach-Object { [string]$_ })
+}
+$ownedRoots = @($InstallRoot, $ocrRuntimeRoot, $appDir)
+
+if ($WhatIfPreference) {
+    [pscustomobject]@{
+        Mode = "WhatIf"
+        InstallRoot = $InstallRoot
+        OcrRuntimeRoot = $ocrRuntimeRoot
+        ShortcutDirectory = $shortcutDirectory
+        ShortcutPath = $shortcutPath
+        CreatedModelDirectories = $createdModelDirectories
+        RemoveSharedModelCache = [bool]$RemoveSharedModelCache
+    }
+    return
+}
+
+Stop-InstalledProcesses -ExpectedExePath $appExe
+
+foreach ($name in $legacyUserEnvironmentVariables) {
+    Remove-UserEnvironmentVariableIfOwned -Name $name -OwnedRoots $ownedRoots | Out-Null
+}
+
+foreach ($name in $persistentEnvironmentVariables) {
+    if ($PSCmdlet.ShouldProcess("User environment variable $name", "Remove")) {
+        [Environment]::SetEnvironmentVariable($name, $null, "User")
+    }
+}
+
+if ($createdModelDirectories.Count -gt 0) {
+    foreach ($modelDirectory in $createdModelDirectories) {
+        if (Test-Path -LiteralPath $modelDirectory -PathType Container) {
+            if ($PSCmdlet.ShouldProcess($modelDirectory, "Remove model directory")) {
+                Remove-Item -LiteralPath $modelDirectory -Recurse -Force
+            }
+        }
+    }
+} elseif ($RemoveSharedModelCache -and $manifest -and $manifest.modelRoot) {
+    @("PP-OCRv5_server_det", "PP-OCRv5_server_rec") | ForEach-Object {
+        $modelDirectory = Join-Path ([string]$manifest.modelRoot) $_
+        if (Test-Path -LiteralPath $modelDirectory -PathType Container) {
+            if ($PSCmdlet.ShouldProcess($modelDirectory, "Remove shared model directory")) {
+                Remove-Item -LiteralPath $modelDirectory -Recurse -Force
+            }
+        }
+    }
+}
+
+if (Test-Path -LiteralPath $shortcutPath -PathType Leaf) {
+    if ($PSCmdlet.ShouldProcess($shortcutPath, "Remove shortcut")) {
+        Remove-Item -LiteralPath $shortcutPath -Force
+    }
+}
+
+if (Test-Path -LiteralPath $shortcutDirectory -PathType Container) {
+    $remaining = @(Get-ChildItem -LiteralPath $shortcutDirectory -Force -ErrorAction SilentlyContinue)
+    if ($remaining.Count -eq 0) {
+        if ($PSCmdlet.ShouldProcess($shortcutDirectory, "Remove shortcut directory")) {
+            Remove-Item -LiteralPath $shortcutDirectory -Force
+        }
+    }
+}
+
+Start-CleanupScript -TargetInstallRoot $InstallRoot -ShortcutDirectory $shortcutDirectory -ShortcutPath $shortcutPath
+
+[pscustomobject]@{
+    InstallRoot = $InstallRoot
+    OcrRuntimeRoot = $ocrRuntimeRoot
+    ShortcutPath = $shortcutPath
+    RemovedModelDirectories = $createdModelDirectories
+}

--- a/tools/release/New-ReleasePackage.ps1
+++ b/tools/release/New-ReleasePackage.ps1
@@ -114,6 +114,8 @@ Get-ChildItem -LiteralPath (Join-Path $packageRoot "app") -Recurse -Filter "*.pd
 Copy-RepoFile -Source "README.md" -Destination "docs\README.md"
 Copy-RepoFile -Source "tools\install\Install-MovieTelopTranscriber.ps1" -Destination "Install-MovieTelopTranscriber.ps1"
 Copy-RepoFile -Source "tools\install\Install-MovieTelopTranscriber.cmd" -Destination "Install-MovieTelopTranscriber.cmd"
+Copy-RepoFile -Source "tools\install\Uninstall-MovieTelopTranscriber.ps1" -Destination "Uninstall-MovieTelopTranscriber.ps1"
+Copy-RepoFile -Source "tools\install\Uninstall-MovieTelopTranscriber.cmd" -Destination "Uninstall-MovieTelopTranscriber.cmd"
 Copy-RepoFileMatch -Directory "docs" -Filter "08_*.md" -DestinationDirectory "docs"
 Copy-RepoFileMatch -Directory "docs" -Filter "09_Windows_OCR*.md" -DestinationDirectory "docs"
 Copy-RepoFileMatch -Directory "docs" -Filter "10_PaddleOCR*.md" -DestinationDirectory "docs"
@@ -137,6 +139,8 @@ $requiredPackageFiles = @(
     "app\tools\ocr\paddle_ocr_worker.py",
     "Install-MovieTelopTranscriber.ps1",
     "Install-MovieTelopTranscriber.cmd",
+    "Uninstall-MovieTelopTranscriber.ps1",
+    "Uninstall-MovieTelopTranscriber.cmd",
     "docs\README.md",
     "samples\basic_telop\README.md",
     "samples\basic_telop\sample_basic_telop.mp4",

--- a/tools/release/New-ReleasePackage.ps1
+++ b/tools/release/New-ReleasePackage.ps1
@@ -113,6 +113,7 @@ Get-ChildItem -LiteralPath (Join-Path $packageRoot "app") -Recurse -Filter "*.pd
 
 Copy-RepoFile -Source "README.md" -Destination "docs\README.md"
 Copy-RepoFile -Source "tools\install\Install-MovieTelopTranscriber.ps1" -Destination "Install-MovieTelopTranscriber.ps1"
+Copy-RepoFile -Source "tools\install\Install-MovieTelopTranscriber.cmd" -Destination "Install-MovieTelopTranscriber.cmd"
 Copy-RepoFileMatch -Directory "docs" -Filter "08_*.md" -DestinationDirectory "docs"
 Copy-RepoFileMatch -Directory "docs" -Filter "09_Windows_OCR*.md" -DestinationDirectory "docs"
 Copy-RepoFileMatch -Directory "docs" -Filter "10_PaddleOCR*.md" -DestinationDirectory "docs"
@@ -135,6 +136,7 @@ $requiredPackageFiles = @(
     "app\MovieTelopTranscriber.App.runtimeconfig.json",
     "app\tools\ocr\paddle_ocr_worker.py",
     "Install-MovieTelopTranscriber.ps1",
+    "Install-MovieTelopTranscriber.cmd",
     "docs\README.md",
     "samples\basic_telop\README.md",
     "samples\basic_telop\sample_basic_telop.mp4",


### PR DESCRIPTION
## 対応内容
- 起動時に `app\movie-telop-transcriber.settings.json` を読み込み、OCR engine、PaddleOCR 用 Python、worker script、主要 OCR 設定を反映する層を追加しました。
- インストーラが `movie-telop-transcriber.settings.json` を生成し、スタートメニューは `MovieTelopTranscriber.App.exe` 直起動を向くように変更しました。
- 配布物へ `Install-MovieTelopTranscriber.cmd` を追加し、利用者が PowerShell コマンドを手入力せずに導入を開始できるようにしました。
- README、導入手順書、実装メモ、開発工程、リリースノート、ルート `AGENTS.md` / `SKILL.md` を更新しました。
- 検証結果を `docs/test-results/2026-04-29_issue122_exe_settings_launch.md` に記録しました。

## 検証
- `dotnet build src\MovieTelopTranscriber.sln -c Release -p:Platform=x64`
- `Install-MovieTelopTranscriber.ps1 -WhatIf`
- `tools\release\New-ReleasePackage.ps1 -Version 0.1.1 -SkipBuild`
- `Install-MovieTelopTranscriber.ps1 -PackageZipPath ... -InstallRoot ... -OcrRuntimeRoot ... -SkipOcrSetup -SkipModelDownload -NoStartMenuShortcut -Force`
- 導入先 `app\movie-telop-transcriber.settings.json` の生成確認
- 導入先 `app\MovieTelopTranscriber.App.exe` の起動直後生存確認

Closes #122