### PR TITLE
Persist main window layout

### DIFF
--- a/src/MovieTelopTranscriber.App/MainPage.xaml
+++ b/src/MovieTelopTranscriber.App/MainPage.xaml
@@ -320,6 +320,7 @@
             <Border
                 x:Name="RightPaneHost"
                 Grid.Column="3"
+                MinWidth="720"
                 Padding="16"
                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"

--- a/src/MovieTelopTranscriber.App/MainPage.xaml.cs
+++ b/src/MovieTelopTranscriber.App/MainPage.xaml.cs
@@ -22,6 +22,8 @@ namespace MovieTelopTranscriber.App;
 /// </summary>
 public sealed partial class MainPage : Page
 {
+    private const double MinimumRightPaneWidth = 720;
+
     public static readonly DependencyProperty TimelineTimeColumnWidthProperty =
         DependencyProperty.Register(nameof(TimelineTimeColumnWidth), typeof(GridLength), typeof(MainPage), new PropertyMetadata(new GridLength(92)));
 
@@ -65,7 +67,7 @@ public sealed partial class MainPage : Page
         DependencyProperty.Register(nameof(TimelineDetailSeparatorWidth), typeof(GridLength), typeof(MainPage), new PropertyMetadata(new GridLength(8)));
 
     public static readonly DependencyProperty RightPaneWidthProperty =
-        DependencyProperty.Register(nameof(RightPaneWidth), typeof(GridLength), typeof(MainPage), new PropertyMetadata(new GridLength(1, GridUnitType.Star)));
+        DependencyProperty.Register(nameof(RightPaneWidth), typeof(GridLength), typeof(MainPage), new PropertyMetadata(new GridLength(760)));
 
     public static readonly DependencyProperty ActivityPaneHeightProperty =
         DependencyProperty.Register(nameof(ActivityPaneHeight), typeof(GridLength), typeof(MainPage), new PropertyMetadata(new GridLength(160)));
@@ -306,7 +308,7 @@ public sealed partial class MainPage : Page
         var currentX = e.GetCurrentPoint(this).Position.X;
         var delta = currentX - _lastRightPaneResizeX;
         _lastRightPaneResizeX = currentX;
-        RightPaneWidth = ResizeGridLength(RightPaneWidth, -delta, 360, RightPaneHost.ActualWidth);
+        RightPaneWidth = ResizeGridLength(RightPaneWidth, -delta, MinimumRightPaneWidth, RightPaneHost.ActualWidth);
         e.Handled = true;
     }
 

--- a/src/MovieTelopTranscriber.App/MainWindow.xaml.cs
+++ b/src/MovieTelopTranscriber.App/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Xaml;
+using MovieTelopTranscriber.App.Services;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -21,9 +22,15 @@ public sealed partial class MainWindow : Window
         SetTitleBar(AppTitleBar);
 
         AppWindow.SetIcon("Assets/AppIcon.ico");
-        AppWindow.Resize(new Windows.Graphics.SizeInt32(1600, 960));
+        AppWindow.Resize(MainWindowLayoutStore.LoadOrDefault());
+        Closed += OnClosed;
 
         // Navigate the root frame to the main page on startup.
         RootFrame.Navigate(typeof(MainPage));
+    }
+
+    private void OnClosed(object sender, WindowEventArgs args)
+    {
+        MainWindowLayoutStore.Save(AppWindow.Size);
     }
 }

--- a/src/MovieTelopTranscriber.App/Services/MainWindowLayoutStore.cs
+++ b/src/MovieTelopTranscriber.App/Services/MainWindowLayoutStore.cs
@@ -1,0 +1,71 @@
+using Windows.Graphics;
+
+namespace MovieTelopTranscriber.App.Services;
+
+internal static class MainWindowLayoutStore
+{
+    private const int DefaultWidth = 1820;
+    private const int DefaultHeight = 1080;
+    private const int MinimumWidth = 1560;
+    private const int MinimumHeight = 920;
+    private const string LayoutFileName = "main-window-layout.json";
+
+    public static SizeInt32 LoadOrDefault()
+    {
+        try
+        {
+            var path = GetLayoutFilePath();
+            if (!File.Exists(path))
+            {
+                return new SizeInt32(DefaultWidth, DefaultHeight);
+            }
+
+            var json = File.ReadAllText(path);
+            using var document = System.Text.Json.JsonDocument.Parse(json);
+            var root = document.RootElement;
+            if (!root.TryGetProperty("width", out var widthElement)
+                || !root.TryGetProperty("height", out var heightElement))
+            {
+                return new SizeInt32(DefaultWidth, DefaultHeight);
+            }
+
+            return new SizeInt32(
+                Math.Max(MinimumWidth, widthElement.GetInt32()),
+                Math.Max(MinimumHeight, heightElement.GetInt32()));
+        }
+        catch
+        {
+            return new SizeInt32(DefaultWidth, DefaultHeight);
+        }
+    }
+
+    public static void Save(SizeInt32 size)
+    {
+        try
+        {
+            var width = Math.Max(MinimumWidth, size.Width);
+            var height = Math.Max(MinimumHeight, size.Height);
+            var path = GetLayoutFilePath();
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var json = $$"""
+                {
+                  "width": {{width}},
+                  "height": {{height}}
+                }
+                """;
+            File.WriteAllText(path, json);
+        }
+        catch
+        {
+            // Keep window layout persistence best-effort so the app never fails on close.
+        }
+    }
+
+    private static string GetLayoutFilePath()
+    {
+        var root = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "MovieTelopTranscriber");
+        return Path.Combine(root, LayoutFileName);
+    }
+}


### PR DESCRIPTION
## 概要
- メインウィンドウサイズをローカル JSON に保存して復元
- 初期表示サイズを見直し、狭すぎる復元サイズを回避
- タイムライン右ペインの既定幅と最小幅を引き上げ

## 検証
- `dotnet build src\MovieTelopTranscriber.sln -c Release -p:Platform=x64`