### PR TITLE
Highlight concurrent preview detections

### DIFF
--- a/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
+++ b/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
@@ -739,11 +739,23 @@ public partial class MainPageViewModel : ObservableObject
 
         var normalizedIndex = ((index % _latestFrameAnalyses.Count) + _latestFrameAnalyses.Count) % _latestFrameAnalyses.Count;
         var next = _latestFrameAnalyses[normalizedIndex];
-        var matchingTimelineRow = TimelineSegments.FirstOrDefault(row => row.FrameIndex == next.Frame.FrameIndex);
+        var matchingRows = TimelineSegments
+            .Where(row => row.FrameIndex == next.Frame.FrameIndex && row.TimestampMs == next.Frame.TimestampMs)
+            .ToArray();
+        var matchingTimelineRow = matchingRows.FirstOrDefault();
 
         if (matchingTimelineRow is not null)
         {
             SelectedTimelineSegment = matchingTimelineRow;
+            if (matchingRows.Length > 1)
+            {
+                UpdatePreview(
+                    matchingTimelineRow.FrameIndex,
+                    matchingTimelineRow.TimestampMs,
+                    matchingTimelineRow.SegmentId,
+                    matchingTimelineRow.Text,
+                    detectionIds: NormalizeDetectionIds(matchingRows.SelectMany(row => row.DetectionIds)));
+            }
         }
         else
         {


### PR DESCRIPTION
## 概要
- プレビュー再生中に同時刻の複数テロップがある場合、強調対象の detection 群をまとめて反映
- プレビュー上で複数枠を同時強調

## 検証
- `dotnet build src\MovieTelopTranscriber.sln -c Release -p:Platform=x64`