### PR TITLE
#133 文字色推定を背景色に引っ張られにくくする

### DIFF
--- a/docs/test-results/2026-04-29_issue133_text_color_estimation.md
+++ b/docs/test-results/2026-04-29_issue133_text_color_estimation.md
@@ -1,0 +1,28 @@
+# Issue 133 文字色推定改善検証
+
+## 概要
+- 対象 Issue: `#133`
+- 実施日: 2026-04-29
+- 対象コード: `src/MovieTelopTranscriber.App/Services/TelopAttributeAnalysisService.cs`
+
+## 変更方針
+- OCR 矩形全体の色分布だけで文字色を決めると、背景帯や背景色の面積が大きいケースで誤判定しやすい。
+- 今回は OCR 矩形の四隅を背景サンプルとして扱い、その色成分を矩形全体の集計から差し引いた前景集計を作る。
+- 文字色は前景集計を優先して `白文字`、`黄文字`、`赤文字`、`青文字`、`緑文字`、`黒文字` の暫定ラベルへ分類する。
+- 枠色は従来どおり OCR 矩形全体の黒/白画素量から `黒枠` または `白縁` を判定する。
+
+## 確認方法
+1. `dotnet build src\MovieTelopTranscriber.sln -c Release -p:Platform=x64`
+2. `test-data/basic_telop/sample_basic_telop.mp4` の `1000ms` と `3000ms` のフレームを抽出する。
+3. `test-data/basic_telop/expected_ocr_by_timestamp.json` の bounding box を使って `TelopAttributeAnalysisService` を実行する。
+
+## 確認結果
+| 時刻 | 想定ケース | 判定結果 |
+| --- | --- | --- |
+| `1000ms` | 青帯の上に白文字、黒枠 | `白文字 / 黒枠` |
+| `3000ms` | 背景帯なしの黄文字、黒枠 | `黄文字 / 黒枠` |
+
+## 所見
+- 背景帯が大きい `1000ms` ケースでも、背景色の青に引っ張られず `白文字` を優先できた。
+- `3000ms` ケースでは背景の暗色を差し引いた結果、`黄文字` を安定して抽出できた。
+- `background_color` は引き続き `null` のままとし、今回の対応では文字色と枠色の暫定ラベル改善に範囲を限定した。

--- a/src/MovieTelopTranscriber.App/Services/TelopAttributeAnalysisService.cs
+++ b/src/MovieTelopTranscriber.App/Services/TelopAttributeAnalysisService.cs
@@ -100,16 +100,21 @@ public sealed class TelopAttributeAnalysisService
             return UnknownStyle();
         }
 
-        var rect = CreateClampedRect(frameImage, boundingBox, padding: 4);
-        if (rect.Width <= 0 || rect.Height <= 0)
+        var baseRect = CreateClampedRect(frameImage, boundingBox, padding: 0);
+        var outerRect = CreateClampedRect(frameImage, boundingBox, padding: 4);
+        if (baseRect.Width <= 0 || baseRect.Height <= 0 || outerRect.Width <= 0 || outerRect.Height <= 0)
         {
             return UnknownStyle();
         }
 
-        using var crop = new Mat(frameImage, rect);
-        var stats = AnalyzeColors(crop);
-        var textColor = SelectTextColor(stats);
-        var strokeColor = SelectStrokeColor(stats, textColor);
+        using var baseCrop = new Mat(frameImage, baseRect);
+        using var outerCrop = new Mat(frameImage, outerRect);
+
+        var baseStats = AnalyzeColors(baseCrop);
+        var cornerStats = AnalyzeCornerColors(outerCrop);
+        var foregroundStats = RemoveBackgroundInfluence(baseStats, cornerStats);
+        var textColor = SelectTextColor(foregroundStats, baseStats);
+        var strokeColor = SelectStrokeColor(baseStats, textColor);
         var textType = CreateTextTypeLabel(textColor, strokeColor);
         return new TelopStyleEstimate(textColor, strokeColor, null, textType);
     }
@@ -126,6 +131,47 @@ public sealed class TelopAttributeAnalysisService
         maxX = Math.Clamp(maxX, minX + 1, image.Width);
         maxY = Math.Clamp(maxY, minY + 1, image.Height);
         return new Rect(minX, minY, maxX - minX, maxY - minY);
+    }
+
+    private static ColorStats AnalyzeCornerColors(Mat crop)
+    {
+        if (crop.Width <= 0 || crop.Height <= 0)
+        {
+            return new ColorStats(1, 0, 0, 0, 0, 0, 0);
+        }
+
+        var cornerWidth = Math.Max(1, crop.Width / 5);
+        var cornerHeight = Math.Max(1, crop.Height / 5);
+        var corners = new[]
+        {
+            new Rect(0, 0, cornerWidth, cornerHeight),
+            new Rect(Math.Max(0, crop.Width - cornerWidth), 0, cornerWidth, cornerHeight),
+            new Rect(0, Math.Max(0, crop.Height - cornerHeight), cornerWidth, cornerHeight),
+            new Rect(Math.Max(0, crop.Width - cornerWidth), Math.Max(0, crop.Height - cornerHeight), cornerWidth, cornerHeight)
+        };
+
+        var total = 0;
+        var white = 0;
+        var black = 0;
+        var green = 0;
+        var red = 0;
+        var blue = 0;
+        var yellow = 0;
+
+        foreach (var corner in corners)
+        {
+            using var roi = new Mat(crop, corner);
+            var stats = AnalyzeColors(roi);
+            total += stats.Total;
+            white += stats.White;
+            black += stats.Black;
+            green += stats.Green;
+            red += stats.Red;
+            blue += stats.Blue;
+            yellow += stats.Yellow;
+        }
+
+        return new ColorStats(Math.Max(1, total), white, black, green, red, blue, yellow);
     }
 
     private static ColorStats AnalyzeColors(Mat crop)
@@ -183,25 +229,44 @@ public sealed class TelopAttributeAnalysisService
         return new ColorStats(total, white, black, green, red, blue, yellow);
     }
 
-    private static string? SelectTextColor(ColorStats stats)
+    private static ColorStats RemoveBackgroundInfluence(ColorStats baseStats, ColorStats cornerStats)
     {
-        var minimum = Math.Max(8, (int)Math.Round(stats.Total * 0.03d));
+        if (cornerStats.Total <= 0)
+        {
+            return baseStats;
+        }
+
+        var scale = (double)baseStats.Total / cornerStats.Total;
+        return new ColorStats(
+            baseStats.Total,
+            RemoveScaledCount(baseStats.White, cornerStats.White, scale),
+            RemoveScaledCount(baseStats.Black, cornerStats.Black, scale),
+            RemoveScaledCount(baseStats.Green, cornerStats.Green, scale),
+            RemoveScaledCount(baseStats.Red, cornerStats.Red, scale),
+            RemoveScaledCount(baseStats.Blue, cornerStats.Blue, scale),
+            RemoveScaledCount(baseStats.Yellow, cornerStats.Yellow, scale));
+    }
+
+    private static int RemoveScaledCount(int totalCount, int sampledCount, double scale)
+    {
+        var estimatedBackground = (int)Math.Round(sampledCount * scale);
+        return Math.Max(0, totalCount - estimatedBackground);
+    }
+
+    private static string? SelectTextColor(ColorStats foregroundStats, ColorStats baseStats)
+    {
+        var minimum = Math.Max(8, (int)Math.Round(baseStats.Total * 0.015d));
         var colored = new[]
         {
-            ("緑文字", stats.Green),
-            ("黄文字", stats.Yellow),
-            ("赤文字", stats.Red),
-            ("青文字", stats.Blue)
+            ("緑文字", foregroundStats.Green),
+            ("黄文字", foregroundStats.Yellow),
+            ("赤文字", foregroundStats.Red),
+            ("青文字", foregroundStats.Blue)
         }
             .OrderByDescending(item => item.Item2)
-            .First();
+            .FirstOrDefault();
 
-        if (colored.Item2 >= minimum && colored.Item2 >= stats.White * 0.75d)
-        {
-            return colored.Item1;
-        }
-
-        if (stats.White >= minimum && stats.White >= stats.Black * 0.35d)
+        if (foregroundStats.White >= minimum && foregroundStats.White >= colored.Item2 * 0.5d)
         {
             return "白文字";
         }
@@ -211,12 +276,22 @@ public sealed class TelopAttributeAnalysisService
             return colored.Item1;
         }
 
-        return stats.Black >= minimum ? "黒文字" : null;
+        if (baseStats.White >= minimum)
+        {
+            return "白文字";
+        }
+
+        if (foregroundStats.Black >= minimum)
+        {
+            return "黒文字";
+        }
+
+        return null;
     }
 
     private static string? SelectStrokeColor(ColorStats stats, string? textColor)
     {
-        var minimum = Math.Max(10, (int)Math.Round(stats.Total * 0.08d));
+        var minimum = Math.Max(10, (int)Math.Round(stats.Total * 0.05d));
         if (textColor != "黒文字" && stats.Black >= minimum)
         {
             return "黒枠";
@@ -224,7 +299,7 @@ public sealed class TelopAttributeAnalysisService
 
         if (textColor != "白文字" && stats.White >= minimum)
         {
-            return "白枠";
+            return "白縁";
         }
 
         return null;
@@ -235,11 +310,11 @@ public sealed class TelopAttributeAnalysisService
         var parts = new[] { textColor, strokeColor }
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .ToArray();
-        return parts.Length == 0 ? "未分類" : string.Join(" / ", parts);
+        return parts.Length == 0 ? "未推定" : string.Join(" / ", parts);
     }
 
     private static TelopStyleEstimate UnknownStyle()
     {
-        return new TelopStyleEstimate(null, null, null, "未分類");
+        return new TelopStyleEstimate(null, null, null, "未推定");
     }
 }


### PR DESCRIPTION
## 概要
- OCR 矩形四隅を背景サンプルとして扱い、背景色成分を差し引いた前景集計で文字色を推定するよう変更
- 枠色判定のしきい値を見直し、文字色推定が背景色優位のケースでも `黒枠` を維持できるよう調整
- `basic_telop` サンプルでの確認結果を検証記録へ追加

## 検証
- `dotnet build src\MovieTelopTranscriber.sln -c Release -p:Platform=x64`
- `test-data/basic_telop/sample_basic_telop.mp4` の `1000ms` で `白文字 / 黒枠`
- `test-data/basic_telop/sample_basic_telop.mp4` の `3000ms` で `黄文字 / 黒枠`