### PR TITLE
#150 PaddleOCR warmup を先行実行する

### DIFF
--- a/docs/test-results/2026-04-29_issue150_paddleocr_warmup.md
+++ b/docs/test-results/2026-04-29_issue150_paddleocr_warmup.md
@@ -1,0 +1,50 @@
+# Issue 150 PaddleOCR warmup 先行実行検証
+
+## 概要
+- 対象 Issue: `#150`
+- 計測日: 2026-04-29
+- 目的: PaddleOCR worker の warmup を先行実行し、初回フレーム待ち時間と体感待ち時間がどう変化するか確認する。
+
+## 実装内容
+- `IOcrWorkerClient.WarmupAsync` を追加した。
+- `PaddleOcrWorkerClient` は OCR 開始前に `warmup.ppm` を使った先行認識を実行する。
+- `MainPageViewModel` は OCR 開始前に warmup を呼び、進捗欄へ `OCR warmup` を表示する。
+- `summary.json` / `run.log` に `ocr_warmup_status` と `ocr_warmup_ms` を追加した。
+
+## 計測条件
+- OCR エンジン: `paddleocr`
+- device: `cpu`
+- language: `ja`
+- preprocess: `true`
+- contrast: `1.1`
+- sharpen: `true`
+- frame interval: `1.0 sec`
+
+## 比較対象
+- 改善前 baseline: [2026-04-29_issue131_ocr_performance_benchmark.md](/abs/path/d:/Claude/Movie/movie-telop-transcriber/docs/test-results/2026-04-29_issue131_ocr_performance_benchmark.md)
+- 改善後: 本 Issue の warmup 実装入り branch で短尺・中尺を再計測
+
+## 比較結果
+| 区分 | 改善前 初回フレーム ms | 改善後 warmup ms | 改善後 初回フレーム ms | 改善率 | 改善前 OCR 合計 ms | 改善後 OCR 合計 ms | warmup + OCR 合計 ms |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 短尺 | 32,476.9 | 16,920.1 | 3,673.1 | -88.7% | 44,321.5 | 15,539.3 | 32,459.4 |
+| 中尺 | 14,810.5 | 17,071.4 | 3,456.9 | -76.7% | 194,143.5 | 206,137.6 | 223,209.0 |
+
+## 観察
+1. 初回フレーム待ち時間は大きく短縮した
+   - 短尺は `32.5s -> 3.7s`
+   - 中尺は `14.8s -> 3.5s`
+2. warmup 自体は約 17 秒かかった
+   - モデル初期化と初回推論コストの大半は warmup 側へ移った
+3. 総待ち時間は一貫して短縮しなかった
+   - 短尺は `warmup + OCR` 合計でも baseline より短かった
+   - 中尺は `warmup + OCR` 合計が baseline より長かった
+4. 体感面では改善がある
+   - OCR 開始後に長時間無反応に見える状態を避けやすくなった
+   - 進捗欄で `OCR warmup` を明示できるようになった
+
+## 判断
+- 本実装は「最初のフレームが極端に遅い」問題には有効。
+- 一方で、warmup を OCR 直前にそのまま追加すると、総待ち時間の短縮は保証されない。
+- 現段階では、体感改善と進捗の可視化を優先した実装としては成立する。
+- 総待ち時間まで安定して削るには、warmup をフレーム抽出中や動画選択直後へ前倒しして重ねる追加改善が必要。

--- a/src/MovieTelopTranscriber.App/Models/OcrWarmupArtifact.cs
+++ b/src/MovieTelopTranscriber.App/Models/OcrWarmupArtifact.cs
@@ -1,0 +1,5 @@
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record OcrWarmupArtifact(
+    string RequestId,
+    string ImagePath);

--- a/src/MovieTelopTranscriber.App/Models/OcrWorkerWarmupResult.cs
+++ b/src/MovieTelopTranscriber.App/Models/OcrWorkerWarmupResult.cs
@@ -1,0 +1,17 @@
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record OcrWorkerWarmupResult(
+    string Status,
+    double RequestWriteMs,
+    double WorkerInitializationMs,
+    double WorkerExecutionMs,
+    double ResponseReadMs,
+    double TotalMs,
+    ProcessingError? Error)
+{
+    public static OcrWorkerWarmupResult Skipped { get; } = new("skipped", 0d, 0d, 0d, 0d, 0d, null);
+
+    public bool Attempted => !string.Equals(Status, "skipped", StringComparison.OrdinalIgnoreCase);
+
+    public bool Succeeded => string.Equals(Status, "success", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/MovieTelopTranscriber.App/Models/RunPerformanceSummaryRecord.cs
+++ b/src/MovieTelopTranscriber.App/Models/RunPerformanceSummaryRecord.cs
@@ -1,11 +1,13 @@
 namespace MovieTelopTranscriber.App.Models;
 
 public sealed record RunPerformanceSummaryRecord(
+    string OcrWarmupStatus,
     double FrameExtractionMs,
     double OcrTotalMs,
     double SegmentMergeMs,
     double ExportWriteMs,
     double LogWriteMs,
+    double OcrWarmupMs,
     double OcrRequestWriteMs,
     double OcrWorkerInitializationMs,
     double OcrWorkerExecutionMs,

--- a/src/MovieTelopTranscriber.App/Services/IOcrWorkerClient.cs
+++ b/src/MovieTelopTranscriber.App/Services/IOcrWorkerClient.cs
@@ -6,6 +6,10 @@ public interface IOcrWorkerClient
 {
     string EngineName { get; }
 
+    Task<OcrWorkerWarmupResult> WarmupAsync(
+        string ocrDirectory,
+        CancellationToken cancellationToken = default);
+
     Task<OcrWorkerExecutionResult> RecognizeAsync(
         OcrWorkerRequest request,
         string ocrDirectory,

--- a/src/MovieTelopTranscriber.App/Services/OcrContractJson.cs
+++ b/src/MovieTelopTranscriber.App/Services/OcrContractJson.cs
@@ -16,6 +16,8 @@ internal static class OcrContractJson
 
     public static JsonTypeInfo<OcrFramePerformanceRecord[]> OcrFramePerformanceRecords => OcrJsonSerializerContext.Default.OcrFramePerformanceRecordArray;
 
+    public static JsonTypeInfo<OcrWorkerWarmupResult> OcrWorkerWarmupResult => OcrJsonSerializerContext.Default.OcrWorkerWarmupResult;
+
     public static JsonTypeInfo<PaddleOcrWorkerAck> PaddleOcrWorkerAck => OcrJsonSerializerContext.Default.PaddleOcrWorkerAck;
 
     public static JsonTypeInfo<RunSummaryRecord> RunSummaryRecord => OcrJsonSerializerContext.Default.RunSummaryRecord;
@@ -33,6 +35,7 @@ internal static class OcrContractJson
 [JsonSerializable(typeof(OcrFramePerformanceRecord[]))]
 [JsonSerializable(typeof(OcrDetectionRecord))]
 [JsonSerializable(typeof(OcrWorkerExecutionResult))]
+[JsonSerializable(typeof(OcrWorkerWarmupResult))]
 [JsonSerializable(typeof(OcrWorkerRequest))]
 [JsonSerializable(typeof(OcrWorkerResponse))]
 [JsonSerializable(typeof(PaddleOcrWorkerAck))]

--- a/src/MovieTelopTranscriber.App/Services/PaddleOcrWorkerClient.cs
+++ b/src/MovieTelopTranscriber.App/Services/PaddleOcrWorkerClient.cs
@@ -43,6 +43,38 @@ public sealed class PaddleOcrWorkerClient : IOcrWorkerClient, IAsyncDisposable, 
 
     public string EngineName => "paddleocr";
 
+    public async Task<OcrWorkerWarmupResult> WarmupAsync(
+        string ocrDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        Directory.CreateDirectory(ocrDirectory);
+
+        var artifact = await CreateWarmupArtifactAsync(ocrDirectory, cancellationToken);
+        var request = new OcrWorkerRequest(
+            artifact.RequestId,
+            -1,
+            -1,
+            artifact.ImagePath,
+            "ja",
+            EngineName);
+
+        var totalStopwatch = Stopwatch.StartNew();
+        var result = await RecognizeAsync(request, ocrDirectory, cancellationToken);
+        totalStopwatch.Stop();
+
+        var status = string.Equals(result.Response.Status, "error", StringComparison.OrdinalIgnoreCase)
+            ? "error"
+            : "success";
+        return new OcrWorkerWarmupResult(
+            status,
+            result.RequestWriteMs,
+            result.WorkerInitializationMs,
+            result.WorkerExecutionMs,
+            result.ResponseReadMs,
+            totalStopwatch.Elapsed.TotalMilliseconds,
+            result.Response.Error);
+    }
+
     public async Task<OcrWorkerExecutionResult> RecognizeAsync(
         OcrWorkerRequest request,
         string ocrDirectory,
@@ -318,6 +350,37 @@ public sealed class PaddleOcrWorkerClient : IOcrWorkerClient, IAsyncDisposable, 
         }
 
         return null;
+    }
+
+    private static async Task<OcrWarmupArtifact> CreateWarmupArtifactAsync(
+        string ocrDirectory,
+        CancellationToken cancellationToken)
+    {
+        var requestId = "ocr-warmup-00000000ms";
+        var imagePath = Path.Combine(ocrDirectory, "warmup.ppm");
+        if (File.Exists(imagePath))
+        {
+            return new OcrWarmupArtifact(requestId, imagePath);
+        }
+
+        const int width = 32;
+        const int height = 32;
+        var builder = new StringBuilder();
+        builder.AppendLine("P3");
+        builder.AppendLine($"{width} {height}");
+        builder.AppendLine("255");
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                builder.Append("255 255 255 ");
+            }
+
+            builder.AppendLine();
+        }
+
+        await File.WriteAllTextAsync(imagePath, builder.ToString(), new UTF8Encoding(false), cancellationToken);
+        return new OcrWarmupArtifact(requestId, imagePath);
     }
 
     private async Task PumpStandardErrorAsync(Process process)

--- a/src/MovieTelopTranscriber.App/Services/ProcessOcrWorkerClient.cs
+++ b/src/MovieTelopTranscriber.App/Services/ProcessOcrWorkerClient.cs
@@ -17,6 +17,13 @@ public sealed class ProcessOcrWorkerClient : IOcrWorkerClient
 
     private bool HasConfiguredWorker => !string.IsNullOrWhiteSpace(WorkerPath);
 
+    public Task<OcrWorkerWarmupResult> WarmupAsync(
+        string ocrDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(OcrWorkerWarmupResult.Skipped);
+    }
+
     public async Task<OcrWorkerExecutionResult> RecognizeAsync(
         OcrWorkerRequest request,
         string ocrDirectory,

--- a/src/MovieTelopTranscriber.App/Services/RunLogWriter.cs
+++ b/src/MovieTelopTranscriber.App/Services/RunLogWriter.cs
@@ -115,11 +115,13 @@ public sealed class RunLogWriter
         builder.AppendLine($"vtt_path={summary.VttPath}");
         builder.AppendLine($"ass_path={summary.AssPath}");
         builder.AppendLine($"ocr_performance_path={summary.OcrPerformancePath}");
+        builder.AppendLine($"ocr_warmup_status={summary.Performance.OcrWarmupStatus}");
         builder.AppendLine($"frame_extraction_ms={summary.Performance.FrameExtractionMs:F1}");
         builder.AppendLine($"ocr_total_ms={summary.Performance.OcrTotalMs:F1}");
         builder.AppendLine($"segment_merge_ms={summary.Performance.SegmentMergeMs:F1}");
         builder.AppendLine($"export_write_ms={summary.Performance.ExportWriteMs:F1}");
         builder.AppendLine($"log_write_ms={summary.Performance.LogWriteMs:F1}");
+        builder.AppendLine($"ocr_warmup_ms={summary.Performance.OcrWarmupMs:F1}");
         builder.AppendLine($"ocr_request_write_ms={summary.Performance.OcrRequestWriteMs:F1}");
         builder.AppendLine($"ocr_worker_initialization_ms={summary.Performance.OcrWorkerInitializationMs:F1}");
         builder.AppendLine($"ocr_worker_execution_ms={summary.Performance.OcrWorkerExecutionMs:F1}");

--- a/src/MovieTelopTranscriber.App/Services/TelopFrameAnalysisService.cs
+++ b/src/MovieTelopTranscriber.App/Services/TelopFrameAnalysisService.cs
@@ -24,6 +24,14 @@ public sealed class TelopFrameAnalysisService
 
     public string EngineName => _ocrWorkerClient.EngineName;
 
+    public Task<OcrWorkerWarmupResult> WarmupAsync(
+        FrameExtractionResult frameExtractionResult,
+        CancellationToken cancellationToken = default)
+    {
+        var ocrDirectory = Path.Combine(frameExtractionResult.RunDirectory, "ocr");
+        return _ocrWorkerClient.WarmupAsync(ocrDirectory, cancellationToken);
+    }
+
     public async Task<IReadOnlyList<FrameAnalysisResult>> AnalyzeFramesAsync(
         FrameExtractionResult frameExtractionResult,
         IProgress<double>? progress = null,

--- a/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
+++ b/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
@@ -1399,6 +1399,7 @@ public partial class MainPageViewModel : ObservableObject
             var startedAt = DateTimeOffset.Now;
             var stopwatch = Stopwatch.StartNew();
             var frameExtractionDurationMs = 0d;
+            var warmupResult = OcrWorkerWarmupResult.Skipped;
             var ocrDurationMs = 0d;
             var segmentMergeDurationMs = 0d;
             var exportWriteDurationMs = 0d;
@@ -1449,6 +1450,14 @@ public partial class MainPageViewModel : ObservableObject
                 currentStage = "OCR";
                 PreviewState = "Running OCR";
                 ActivityMessage = "OCR worker is processing extracted frames.";
+                ProgressDetailText = "OCR warmup: preparing worker.";
+                warmupResult = await _frameAnalysisService.WarmupAsync(result);
+                if (warmupResult.Attempted)
+                {
+                    ActivityMessage = warmupResult.Succeeded
+                        ? "OCR warmup completed. Processing extracted frames."
+                        : "OCR warmup failed. Continuing with extracted frames.";
+                }
                 var ocrProgress = new Progress<double>(value =>
                 {
                     ProgressValue = 60d + (value * 0.3d);
@@ -1512,6 +1521,7 @@ public partial class MainPageViewModel : ObservableObject
             currentStage = "Logging";
             ProgressDetailText = $"Logging: writing run summary for {result.Frames.Count} frames.";
             var performanceSummary = BuildPerformanceSummary(
+                warmupResult,
                 _latestFrameAnalyses,
                 frameExtractionDurationMs,
                 ocrDurationMs,
@@ -2502,6 +2512,7 @@ public partial class MainPageViewModel : ObservableObject
     }
 
     private static RunPerformanceSummaryRecord BuildPerformanceSummary(
+        OcrWorkerWarmupResult warmupResult,
         IReadOnlyList<FrameAnalysisResult> frameAnalyses,
         double frameExtractionDurationMs,
         double ocrDurationMs,
@@ -2519,11 +2530,13 @@ public partial class MainPageViewModel : ObservableObject
             : framePerformances.Max(performance => performance.TotalMs);
 
         return new RunPerformanceSummaryRecord(
+            warmupResult.Status,
             frameExtractionDurationMs,
             ocrDurationMs,
             segmentMergeDurationMs,
             exportWriteDurationMs,
             logWriteDurationMs,
+            warmupResult.TotalMs,
             framePerformances.Sum(performance => performance.RequestWriteMs),
             framePerformances.Sum(performance => performance.WorkerInitializationMs),
             framePerformances.Sum(performance => performance.WorkerExecutionMs),


### PR DESCRIPTION
## 概要
- OCR 開始前に PaddleOCR worker の warmup を先行実行する
- 進捗欄に `OCR warmup` を表示する
- `summary.json` / `run.log` に warmup 状態と時間を残す
- warmup の改善前後比較を検証レポートに整理する

## 検証
- `dotnet build src\MovieTelopTranscriber.sln -c Release -p:Platform=x64`
- 短尺・中尺サンプルで warmup ありの比較計測

## 関連
- Closes #150
- Follow-up: #154