### PR TITLE
#154 OCR warmup を前倒しして総待ち時間を隠蔽する

### DIFF
--- a/docs/test-results/2026-04-29_issue154_warmup_overlap.md
+++ b/docs/test-results/2026-04-29_issue154_warmup_overlap.md
@@ -1,0 +1,59 @@
+# Issue 154 OCR warmup 前倒し検証
+
+## 概要
+- 対象 Issue: `#154`
+- 計測日: 2026-04-29
+- 目的: OCR warmup をフレーム抽出前後へ前倒しし、総待ち時間をどこまで隠蔽できるか確認する。
+
+## 実装内容
+- 動画メタデータ読込後に PaddleOCR warmup をバックグラウンド開始する。
+- フレーム抽出中は warmup を並行実行する。
+- OCR 開始時は、未完了なら warmup 完了だけを待ってから OCR 本処理へ進む。
+- warmup 用ファイルは一時ディレクトリで処理し、完了後に削除する。
+
+## 比較対象
+- baseline 1: `#131` の warmup なし
+- baseline 2: `#150` の OCR 直前 warmup
+- 今回: metadata 読込後に background warmup を開始し、フレーム抽出と重ねる
+
+## 計測条件
+- OCR エンジン: `paddleocr`
+- device: `cpu`
+- language: `ja`
+- preprocess: `true`
+- contrast: `1.1`
+- sharpen: `true`
+- frame interval: `1.0 sec`
+
+## 比較結果
+| 区分 | #150 直列 warmup 合計 ms | #154 前倒し合計 ms | 差分 | 改善率 | #154 初回フレーム ms |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 短尺 | 32,561.9 | 29,254.6 | -3,307.3 | -10.2% | 3,127.3 |
+| 中尺 | 223,878.3 | 181,079.1 | -42,799.2 | -19.1% | 2,699.7 |
+
+計算方法:
+- `#150 直列 warmup 合計 ms = frame_extraction_ms + ocr_warmup_ms + ocr_total_ms`
+- `#154 前倒し合計 ms = metadata 読込直後から OCR 完了までの実測 wall-clock`
+
+## 観察
+1. `#150` より総待ち時間は短縮した
+   - warmup を抽出と重ねることで、待機時間の一部を隠蔽できた。
+2. 初回フレーム待ち時間も引き続き抑えられている
+   - 短尺 `3.1s`
+   - 中尺 `2.7s`
+3. 抽出時間が短い動画では改善幅は限定的
+   - 短尺では抽出が約 `0.1s` のため、前倒しの主な効果は「動画選択後の待機中」に依存する。
+4. 中尺では総待ち時間の改善が確認できた
+   - 抽出時間と warmup を重ねたぶん、直列実行より差が出た。
+
+## 進捗表示方針
+- 動画選択後: `Metadata loaded. OCR warmup is running in background.`
+- OCR 開始時:
+  - warmup 完了済みならそのまま OCR 進行へ入る
+  - 未完了なら `OCR warmup: preparing worker.` を表示して待つ
+  - warmup 失敗時は `OCR warmup failed. Continuing with extracted frames.` として本処理へ進む
+
+## 判断
+- `#150` の直列 warmup より、前倒しのほうが総待ち時間を下げやすい。
+- 特に利用者が動画選択後すぐに開始しない運用では、体感待ち時間の隠蔽効果が大きい。
+- 直後実行ケースでも一定の改善があるため、本方式は採用してよい。

--- a/src/MovieTelopTranscriber.App/Services/TelopFrameAnalysisService.cs
+++ b/src/MovieTelopTranscriber.App/Services/TelopFrameAnalysisService.cs
@@ -32,6 +32,14 @@ public sealed class TelopFrameAnalysisService
         return _ocrWorkerClient.WarmupAsync(ocrDirectory, cancellationToken);
     }
 
+    public Task<OcrWorkerWarmupResult> WarmupAsync(
+        string workDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        var ocrDirectory = Path.Combine(workDirectory, "ocr");
+        return _ocrWorkerClient.WarmupAsync(ocrDirectory, cancellationToken);
+    }
+
     public async Task<IReadOnlyList<FrameAnalysisResult>> AnalyzeFramesAsync(
         FrameExtractionResult frameExtractionResult,
         IProgress<double>? progress = null,

--- a/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
+++ b/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
@@ -73,6 +73,8 @@ public partial class MainPageViewModel : ObservableObject
     private readonly DispatcherQueue? _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
     private ProgressFrameState? _activeProgressFrameState;
     private int _manualEditSequence;
+    private Task<OcrWorkerWarmupResult>? _pendingOcrWarmupTask;
+    private string? _pendingOcrWarmupSettingsSignature;
 
     public MainPageViewModel()
     {
@@ -1416,6 +1418,7 @@ public partial class MainPageViewModel : ObservableObject
             {
                 currentStage = "Video metadata";
                 metadata = await _videoProcessingService.ReadMetadataAsync(VideoPath);
+                EnsureBackgroundOcrWarmupStarted();
                 _latestMetadata = metadata;
                 _latestFrameIntervalSeconds = intervalSeconds;
 
@@ -1450,13 +1453,10 @@ public partial class MainPageViewModel : ObservableObject
                 currentStage = "OCR";
                 PreviewState = "Running OCR";
                 ActivityMessage = "OCR worker is processing extracted frames.";
-                ProgressDetailText = "OCR warmup: preparing worker.";
-                warmupResult = await _frameAnalysisService.WarmupAsync(result);
-                if (warmupResult.Attempted)
+                warmupResult = await ResolveOcrWarmupAsync();
+                if (warmupResult.Attempted && !warmupResult.Succeeded)
                 {
-                    ActivityMessage = warmupResult.Succeeded
-                        ? "OCR warmup completed. Processing extracted frames."
-                        : "OCR warmup failed. Continuing with extracted frames.";
+                    ActivityMessage = "OCR warmup failed. Continuing with extracted frames.";
                 }
                 var ocrProgress = new Progress<double>(value =>
                 {
@@ -1641,9 +1641,12 @@ public partial class MainPageViewModel : ObservableObject
             _latestExport = null;
             _latestFrameIntervalSeconds = ParseFrameIntervalSeconds();
             ClearPipelineFailure();
+            EnsureBackgroundOcrWarmupStarted();
             PreviewState = "Ready";
             StatusMessage = $"Loaded {metadata.FileName}";
-            ActivityMessage = "Metadata loaded. You can now run frame extraction.";
+            ActivityMessage = _pendingOcrWarmupTask is null
+                ? "Metadata loaded. You can now run frame extraction."
+                : "Metadata loaded. OCR warmup is running in background.";
             ProgressDetailText = "Metadata loaded.";
 
             RefreshInfoCards(metadata, 0, 0, 0);
@@ -1701,6 +1704,118 @@ public partial class MainPageViewModel : ObservableObject
         ResultRows.Add(new ResultRow("result", "Status", "No extracted frames", "Run frame extraction to populate this list."));
         SelectFirstPreviewSelection();
         ClearPreview("Video not loaded", "Select a video file to display frame preview.");
+    }
+
+    private void EnsureBackgroundOcrWarmupStarted()
+    {
+        if (!string.Equals(_frameAnalysisService.EngineName, "paddleocr", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var signature = CreateOcrWarmupSettingsSignature();
+        if (_pendingOcrWarmupTask is not null
+            && string.Equals(_pendingOcrWarmupSettingsSignature, signature, StringComparison.Ordinal)
+            && !_pendingOcrWarmupTask.IsCanceled
+            && !_pendingOcrWarmupTask.IsFaulted)
+        {
+            return;
+        }
+
+        _pendingOcrWarmupSettingsSignature = signature;
+        _pendingOcrWarmupTask = RunOcrWarmupWithIsolatedDirectoryAsync(CancellationToken.None);
+    }
+
+    private async Task<OcrWorkerWarmupResult> ResolveOcrWarmupAsync(CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(_frameAnalysisService.EngineName, "paddleocr", StringComparison.OrdinalIgnoreCase))
+        {
+            return OcrWorkerWarmupResult.Skipped;
+        }
+
+        EnsureBackgroundOcrWarmupStarted();
+        if (_pendingOcrWarmupTask is null)
+        {
+            return OcrWorkerWarmupResult.Skipped;
+        }
+
+        if (!_pendingOcrWarmupTask.IsCompleted)
+        {
+            ProgressDetailText = "OCR warmup: preparing worker.";
+        }
+
+        var result = await _pendingOcrWarmupTask.WaitAsync(cancellationToken);
+        _pendingOcrWarmupTask = null;
+        return result;
+    }
+
+    private async Task<OcrWorkerWarmupResult> RunOcrWarmupWithIsolatedDirectoryAsync(CancellationToken cancellationToken)
+    {
+        var workDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "MovieTelopTranscriber",
+            "ocr-warmup",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDirectory);
+
+        try
+        {
+            return await _frameAnalysisService.WarmupAsync(workDirectory, cancellationToken);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            return new OcrWorkerWarmupResult(
+                "error",
+                0d,
+                0d,
+                0d,
+                0d,
+                0d,
+                new ProcessingError("OCR_WARMUP_FAILED", "OCR warmup could not be completed.", ex.Message, true));
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(workDirectory))
+                {
+                    Directory.Delete(workDirectory, recursive: true);
+                }
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    private string CreateOcrWarmupSettingsSignature()
+    {
+        return string.Join(
+            "\n",
+            new[]
+            {
+                _frameAnalysisService.EngineName,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_PYTHON") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_SCRIPT") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_DEVICE") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_LANG") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_MIN_SCORE") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_NORMALIZE_SMALL_KANA") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_PREPROCESS") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_UPSCALE") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_CONTRAST") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_SHARPEN") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_TEXT_DET_THRESH") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_TEXT_DET_BOX_THRESH") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_TEXT_DET_UNCLIP_RATIO") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_TEXT_DET_LIMIT_SIDE_LEN") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_MIN_TEXT_SIZE") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_USE_TEXTLINE_ORIENTATION") ?? string.Empty,
+                Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_USE_DOC_UNWARPING") ?? string.Empty
+            });
     }
 
     private void RefreshInfoCards(VideoMetadata? metadata, int frameCount, int detectionCount, int segmentCount)


### PR DESCRIPTION
## 概要
- 動画メタデータ読込後に OCR warmup をバックグラウンド開始する
- フレーム抽出中に warmup を並行実行し、OCR 開始時は未完了ぶんだけ待つ
- warmup 用一時ディレクトリを使い、完了後に削除する
- 前倒し前後の総待ち時間比較を検証レポートへ整理する

## 検証
- `dotnet build src\MovieTelopTranscriber.sln -c Release -p:Platform=x64`
- 短尺・中尺サンプルで前倒し後の total wait を比較計測

## 関連
- Closes #154
- Related: #150 #131