### PR TITLE
#152 OCR worker 並列化 / バッチ化評価を追加する

### DIFF
--- a/docs/test-results/2026-04-29_issue152_parallel_batch_evaluation.md
+++ b/docs/test-results/2026-04-29_issue152_parallel_batch_evaluation.md
@@ -1,0 +1,77 @@
+# Issue 152 OCR worker 並列化 / バッチ化評価
+
+## 概要
+- 対象 Issue: `#152`
+- 計測日: 2026-04-29
+- 目的: OCR worker の並列化またはバッチ化が、長尺ケースの総待ち時間短縮に有効かを評価する。
+
+## 評価対象
+1. 単一 worker 直列実行
+2. 2 workers 並列実行
+3. 3 workers 並列実行
+4. バッチ化可否の実装観点レビュー
+
+## 計測条件
+- 動画: `test-data/basic_telop/botirist.mp4`
+- 対象フレーム: 先頭 40 フレーム
+- OCR エンジン: `paddleocr`
+- device: `cpu`
+- language: `ja`
+- preprocess: `true`
+- contrast: `1.1`
+- sharpen: `true`
+- 各 worker は warmup 済みで計測
+
+## 計測結果
+| モード | worker 数 | wall-clock ms | worker execution 合計 ms | 平均フレーム ms | 最大フレーム ms | error |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 単一 worker 直列 | 1 | 73,332.3 | 72,915.6 | 1,833.3 | 4,070.8 | 0 |
+| 2 workers 並列 | 2 | 62,067.7 | 122,790.0 | 3,076.5 | 5,052.9 | 0 |
+| 3 workers 並列 | 3 | 92,446.8 | 273,643.6 | 6,850.2 | 11,478.1 | 0 |
+
+## 観察
+1. 2 workers 並列は wall-clock を約 15.4% 短縮した
+   - `73.3s -> 62.1s`
+   - ただし worker execution 合計は大きく増えており、CPU 資源を強く取り合っている
+2. 3 workers 並列は明確に悪化した
+   - wall-clock も平均フレーム時間も増加
+   - CPU 前提では過並列になっている
+3. スパイクは 2 workers でも残る
+   - 最大フレーム時間は `4.1s -> 5.1s` とむしろ少し悪化
+4. warmup コストも worker 数に比例して増えやすい
+   - 2 workers: `22.3s`
+   - 3 workers: `60.5s`
+
+## バッチ化の可否
+- 現行 `tools/ocr/paddle_ocr_worker.py` は 1 回のコマンドで `request_path` と `response_path` を 1 つずつ受け取る設計
+- `recognize()` も単一画像パスを前提に `ocr.predict()` を呼んでいる
+- そのため、現行契約のままでは batch 実験はできない
+- batch を試すには、少なくとも次が必要
+  - request / response JSON 契約の拡張
+  - stdio コマンド形式の変更
+  - worker 側で複数画像をまとめて処理する実装
+  - App 側で複数フレームを束ねる呼び出し経路
+
+## 実装コストと期待効果
+- 2 workers 並列:
+  - 実装コスト: 中
+  - 期待効果: CPU では限定的
+  - リスク: CPU 使用率上昇、warmup 増加、スパイク残存
+- 3 workers 以上:
+  - 実装コスト: 中
+  - 期待効果: CPU では低い
+  - リスク: 悪化が見えているため採用非推奨
+- バッチ化:
+  - 実装コスト: 高
+  - 期待効果: 未測定
+  - リスク: 契約変更範囲が広く、今回の CPU-only 環境では有効性未確認
+
+## 判断
+- 現時点の既定環境が CPU である限り、複数 worker 並列をそのまま本実装へ入れる優先度は高くない。
+- 2 workers 並列は一定の wall-clock 改善があるが、改善幅に対してコストと負荷増が重い。
+- 3 workers 並列は採用しない。
+- batch 化は別設計トラックとして扱うべきで、今回の Issue では採用判断に進めない。
+
+## 次に試す方式
+- GPU 環境で 2 workers 並列を再評価する。
+- CPU 前提の既定経路では、`#151` の候補選別と `#154` の warmup 前倒しを維持する。

--- a/tools/validation/OcrWorkerModeBenchmark/OcrWorkerModeBenchmark.csproj
+++ b/tools/validation/OcrWorkerModeBenchmark/OcrWorkerModeBenchmark.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\MovieTelopTranscriber.App\MovieTelopTranscriber.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/validation/OcrWorkerModeBenchmark/Program.cs
+++ b/tools/validation/OcrWorkerModeBenchmark/Program.cs
@@ -1,0 +1,179 @@
+using MovieTelopTranscriber.App.Models;
+using MovieTelopTranscriber.App.Services;
+using System.Diagnostics;
+using System.Text.Json;
+
+var repoRoot = ResolveRepoRoot();
+ConfigurePaddleOcrEnvironment(repoRoot);
+
+var videoService = new OpenCvVideoProcessingService();
+var benchmarkRoot = Path.Combine(repoRoot, "temp", "issue152-benchmark-runs");
+Directory.CreateDirectory(benchmarkRoot);
+
+var videoPath = Path.Combine(repoRoot, "test-data", "basic_telop", "botirist.mp4");
+var metadata = await videoService.ReadMetadataAsync(videoPath);
+var extraction = await videoService.ExtractFramesAsync(metadata, 1.0d, null, benchmarkRoot);
+var targetFrames = extraction.Frames.Take(40).ToArray();
+
+var results = new List<BenchmarkResult>
+{
+    await BenchmarkAsync("single_worker_serial", targetFrames, workerCount: 1),
+    await BenchmarkAsync("two_workers_parallel", targetFrames, workerCount: 2),
+    await BenchmarkAsync("three_workers_parallel", targetFrames, workerCount: 3)
+};
+
+Console.WriteLine(JsonSerializer.Serialize(results, new JsonSerializerOptions
+{
+    WriteIndented = true
+}));
+
+static async Task<BenchmarkResult> BenchmarkAsync(
+    string modeName,
+    IReadOnlyList<ExtractedFrameRecord> frames,
+    int workerCount)
+{
+    var clients = Enumerable.Range(0, workerCount)
+        .Select(_ => new PaddleOcrWorkerClient())
+        .ToArray();
+
+    try
+    {
+        var benchmarkDirectory = Path.Combine(
+            ResolveRepoRoot(),
+            "temp",
+            "issue152-worker-bench",
+            modeName,
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(benchmarkDirectory);
+
+        var warmupTasks = clients
+            .Select((client, index) => client.WarmupAsync(Path.Combine(benchmarkDirectory, $"worker-{index + 1:D2}")))
+            .ToArray();
+        var warmups = await Task.WhenAll(warmupTasks);
+
+        var perFrameResults = new List<FrameModeResult>();
+        var wallClock = Stopwatch.StartNew();
+        var workerTasks = Enumerable.Range(0, workerCount)
+            .Select(workerIndex => RunWorkerPartitionAsync(
+                clients[workerIndex],
+                workerIndex,
+                workerCount,
+                frames,
+                benchmarkDirectory))
+            .ToArray();
+        var partitions = await Task.WhenAll(workerTasks);
+        wallClock.Stop();
+
+        foreach (var partition in partitions)
+        {
+            perFrameResults.AddRange(partition);
+        }
+
+        var ordered = perFrameResults.OrderBy(result => result.TimestampMs).ToArray();
+        return new BenchmarkResult(
+            modeName,
+            workerCount,
+            frames.Count,
+            Math.Round(wallClock.Elapsed.TotalMilliseconds, 1),
+            Math.Round(warmups.Sum(item => item.TotalMs), 1),
+            Math.Round(ordered.Sum(item => item.TotalMs), 1),
+            Math.Round(ordered.Sum(item => item.WorkerExecutionMs), 1),
+            Math.Round(ordered.Average(item => item.TotalMs), 1),
+            Math.Round(ordered.Max(item => item.TotalMs), 1),
+            ordered.Count(item => string.Equals(item.Status, "success", StringComparison.OrdinalIgnoreCase)),
+            ordered.Count(item => string.Equals(item.Status, "error", StringComparison.OrdinalIgnoreCase)));
+    }
+    finally
+    {
+        foreach (var client in clients)
+        {
+            await client.DisposeAsync();
+        }
+    }
+}
+
+static async Task<IReadOnlyList<FrameModeResult>> RunWorkerPartitionAsync(
+    PaddleOcrWorkerClient client,
+    int workerIndex,
+    int workerCount,
+    IReadOnlyList<ExtractedFrameRecord> frames,
+    string benchmarkDirectory)
+{
+    var results = new List<FrameModeResult>();
+    var workerDirectory = Path.Combine(benchmarkDirectory, $"worker-{workerIndex + 1:D2}");
+
+    for (var frameIndex = workerIndex; frameIndex < frames.Count; frameIndex += workerCount)
+    {
+        var frame = frames[frameIndex];
+        var request = new OcrWorkerRequest(
+            $"issue152-{workerIndex + 1:D2}-{frame.FrameIndex:D6}-{frame.TimestampMs:D8}ms",
+            frame.FrameIndex,
+            frame.TimestampMs,
+            frame.ImagePath,
+            "ja",
+            client.EngineName);
+
+        var startedAt = Stopwatch.StartNew();
+        var response = await client.RecognizeAsync(request, workerDirectory);
+        startedAt.Stop();
+        results.Add(new FrameModeResult(
+            frame.FrameIndex,
+            frame.TimestampMs,
+            response.Response.Status,
+            Math.Round(startedAt.Elapsed.TotalMilliseconds, 1),
+            Math.Round(response.WorkerExecutionMs, 1)));
+    }
+
+    return results;
+}
+
+static string ResolveRepoRoot()
+{
+    var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+    while (current is not null)
+    {
+        if (Directory.Exists(Path.Combine(current.FullName, "src"))
+            && Directory.Exists(Path.Combine(current.FullName, "tools")))
+        {
+            return current.FullName;
+        }
+
+        current = current.Parent;
+    }
+
+    throw new InvalidOperationException("Repository root could not be resolved.");
+}
+
+static void ConfigurePaddleOcrEnvironment(string repoRoot)
+{
+    Environment.SetEnvironmentVariable("MOVIE_TELOP_OCR_ENGINE", "paddleocr");
+    Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_PYTHON", Path.Combine(repoRoot, "temp", "ocr-eval", ".venv", "Scripts", "python.exe"));
+    Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_SCRIPT", Path.Combine(repoRoot, "tools", "ocr", "paddle_ocr_worker.py"));
+    Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_DEVICE", "cpu");
+    Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_LANG", "ja");
+    Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_MIN_SCORE", "0.5");
+    Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_NORMALIZE_SMALL_KANA", "true");
+    Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_PREPROCESS", "true");
+    Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_CONTRAST", "1.1");
+    Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_SHARPEN", "true");
+}
+
+sealed record FrameModeResult(
+    int FrameIndex,
+    long TimestampMs,
+    string Status,
+    double TotalMs,
+    double WorkerExecutionMs);
+
+sealed record BenchmarkResult(
+    string ModeName,
+    int WorkerCount,
+    int FrameCount,
+    double WallClockMs,
+    double WarmupTotalMs,
+    double OcrTotalMs,
+    double WorkerExecutionTotalMs,
+    double AverageFrameMs,
+    double MaxFrameMs,
+    int SuccessCount,
+    int ErrorCount);


### PR DESCRIPTION
## 概要
- OCR worker モード比較用ベンチツールを追加する
- 単一 worker / 2 workers / 3 workers を CPU 条件で比較する
- batch 可否を現行 worker 契約から整理する
- 調査結果を検証レポートに整理する

## 検証
- `dotnet build tools\validation\OcrWorkerModeBenchmark\OcrWorkerModeBenchmark.csproj -c Release`
- `dotnet run --project tools\validation\OcrWorkerModeBenchmark\OcrWorkerModeBenchmark.csproj -c Release`

## 関連
- Closes #152
- Follow-up: #158