### PR TITLE
#135 利用者設定を JSON へ統合して起動時に読み戻す

### DIFF
--- a/docs/14_設定ファイル仕様.md
+++ b/docs/14_設定ファイル仕様.md
@@ -1,0 +1,78 @@
+# 設定ファイル仕様
+
+## 目的
+- 利用者が調整する OCR、出力、表示、ウィンドウ系の主要設定を 1 つの JSON に集約する。
+- アプリ起動時は同じ JSON を読み込み、設定変更時は同じ JSON へ保存する。
+
+## 対象ファイル
+- 既定ファイル名: `movie-telop-transcriber.settings.json`
+
+## 読み込み優先順位
+1. 実行中 `App.exe` と同じ `app` フォルダ内の `movie-telop-transcriber.settings.json`
+2. 配布 zip 側 `app` から起動された場合は、隣接する導入済み `MovieTelopTranscriber\app\movie-telop-transcriber.settings.json`
+3. どちらも見つからない場合は、環境変数とアプリ既定値で起動する
+
+## 保存方針
+- 既存の設定ファイルを読めた場合は、そのファイルへ上書き保存する。
+- 設定ファイルが存在しない場合は、実行中 `App.exe` と同じ `app` フォルダへ新規作成する。
+- UI 変更による保存対象は次のとおり。
+  - 表示言語
+  - 抽出間隔
+  - 出力先フォルダ
+  - OCR 前処理、検出、最小文字サイズ
+  - メイン画面サイズ
+
+## JSON 構造
+```json
+{
+  "ocrEngine": "paddleocr",
+  "ocrWorkerPath": null,
+  "paddleOcr": {
+    "pythonPath": ".\\..\\ocr-runtime\\.venv\\Scripts\\python.exe",
+    "scriptPath": ".\\..\\tools\\ocr\\paddle_ocr_worker.py",
+    "device": "cpu",
+    "language": "ja",
+    "minScore": 0.5,
+    "normalizeSmallKana": true,
+    "preprocess": true,
+    "contrast": 1.1,
+    "sharpen": true,
+    "textDetThresh": 0.3,
+    "textDetBoxThresh": 0.6,
+    "textDetUnclipRatio": 1.5,
+    "textDetLimitSideLen": 960,
+    "useTextlineOrientation": false,
+    "useDocUnwarping": false,
+    "minTextSize": 0.0
+  },
+  "ui": {
+    "language": "ja",
+    "frameIntervalSeconds": 1.0,
+    "outputRootDirectory": ".\\work\\runs",
+    "mainWindow": {
+      "width": 1820,
+      "height": 1080
+    }
+  }
+}
+```
+
+## 互換性
+- 既存の OCR 設定だけを持つ JSON も読み込み可能とする。
+- `ui` セクションが存在しない場合は、表示言語、抽出間隔、出力先、画面サイズは既定値で起動する。
+- 旧 `main-window-layout.json` が残っている場合、`ui.mainWindow` が未設定のときだけ読み込み fallback として扱う。
+
+## パス解決
+- `pythonPath`、`scriptPath`、`outputRootDirectory` は相対パス記載を許容する。
+- 相対パスは `movie-telop-transcriber.settings.json` の配置ディレクトリ基準で解決する。
+- 保存時は、設定ファイル配下へ収まるパスは相対化を優先し、それ以外は絶対パスのまま保存する。
+
+## 破損時の扱い
+- JSON 全体が壊れている場合は読み込みを中止し、従来どおり環境変数とアプリ既定値で継続する。
+- 個別項目が欠けている場合は、その項目だけ既定値へフォールバックする。
+- 読み込み失敗の詳細は `MOVIE_TELOP_LAUNCH_SETTINGS_LOAD_ERROR` に残す。
+
+## 保守方針
+- 利用者が調整する設定は、原則としてこの JSON を正本とする。
+- 将来設定項目を増やす場合も、まずはこの JSON へ集約できるかを優先して検討する。
+- 開発用や内部運用専用の設定を別管理にしたくなった場合だけ、別 JSON の導入を検討する。

--- a/docs/test-results/2026-04-29_issue135_user_settings_json.md
+++ b/docs/test-results/2026-04-29_issue135_user_settings_json.md
@@ -1,0 +1,47 @@
+# Issue 135 利用者設定 JSON 統合
+
+## 対象
+- 対象 Issue: `#135`
+- 実施日: 2026-04-29
+
+## 目的
+- `movie-telop-transcriber.settings.json` を、OCR 起動専用ではなく、利用者が調整する主要設定の保存先としても使えるように整理する。
+- UI から変更する設定と、起動時に読む設定の保存場所を 1 つに揃える。
+
+## 実装内容
+- `AppLaunchSettings` に `ui` セクションを追加した。
+  - `language`
+  - `frameIntervalSeconds`
+  - `outputRootDirectory`
+  - `mainWindow.width`
+  - `mainWindow.height`
+- `AppLaunchSettingsLoader` を読み込み専用から、`Load` / `Apply` / `Save` を持つ設定ストアとして整理した。
+- `MainPageViewModel` は起動時に `ui` セクションを反映し、言語、抽出間隔、出力先、OCR 調整値の変更時に同じ JSON へ保存するようにした。
+- `MainWindowLayoutStore` は従来の別ファイル保存に加えて、優先的に `ui.mainWindow` を使うようにし、終了時は同じ JSON へ保存するようにした。
+- インストーラが生成する `movie-telop-transcriber.settings.json` にも `ui` 初期値を書き込むようにした。
+- 設定仕様を `docs/14_設定ファイル仕様.md` として追加した。
+
+## 保存対象
+- 表示言語
+- 抽出間隔
+- 出力先フォルダ
+- PaddleOCR 前処理
+- PaddleOCR 検出しきい値
+- 最小文字サイズ
+- メイン画面サイズ
+
+## 読み込みと互換性
+- 既存の OCR 設定だけを持つ JSON もそのまま読める。
+- `ui` セクションがない場合は既定値で起動する。
+- 配布 zip 側 `app` からの起動時は、従来どおり隣接する導入済み `MovieTelopTranscriber\app\movie-telop-transcriber.settings.json` fallback を維持する。
+- 旧 `main-window-layout.json` は、`ui.mainWindow` が未設定のときだけ fallback として読む。
+
+## 検証
+| 項目 | コマンド | 結果 |
+| --- | --- | --- |
+| Release build | `dotnet build src\\MovieTelopTranscriber.sln -c Release -p:Platform=x64` | 成功。0 warnings / 0 errors |
+| 差分整合 | `git diff --check` | 成功 |
+
+## 補足
+- 今回は WinUI 画面の手動操作までは未実施で、コード経路と build を中心に確認した。
+- 次の `#134` では、この設定 JSON を前提にプロジェクトファイル側の保存責務を分離しやすくなった。

--- a/src/MovieTelopTranscriber.App/App.xaml.cs
+++ b/src/MovieTelopTranscriber.App/App.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
+using MovieTelopTranscriber.App.Models;
 using MovieTelopTranscriber.App.Services;
 
 // To learn more about WinUI, the WinUI project structure,
@@ -37,13 +38,20 @@ public partial class App : Application
     public static nint WindowHandle =>
         WinRT.Interop.WindowNative.GetWindowHandle(Window);
 
+    public static AppLaunchSettings LaunchSettings { get; private set; } = new();
+
+    public static string? LaunchSettingsPath { get; private set; }
+
     /// <summary>
     /// Initializes the singleton application object.
     /// </summary>
     public App()
     {
         InitializeComponent();
-        AppLaunchSettingsLoader.Apply();
+        var loadResult = AppLaunchSettingsLoader.Load();
+        LaunchSettings = loadResult.Settings;
+        LaunchSettingsPath = loadResult.SettingsPath;
+        AppLaunchSettingsLoader.Apply(loadResult.Settings, loadResult.SettingsPath, loadResult.LoadError);
     }
 
     /// <summary>

--- a/src/MovieTelopTranscriber.App/Models/AppLaunchSettings.cs
+++ b/src/MovieTelopTranscriber.App/Models/AppLaunchSettings.cs
@@ -7,6 +7,8 @@ public sealed class AppLaunchSettings
     public string? OcrWorkerPath { get; set; }
 
     public PaddleOcrLaunchSettings? PaddleOcr { get; set; }
+
+    public UserInterfaceSettings? Ui { get; set; }
 }
 
 public sealed class PaddleOcrLaunchSettings
@@ -42,4 +44,22 @@ public sealed class PaddleOcrLaunchSettings
     public bool? UseDocUnwarping { get; set; }
 
     public double? MinTextSize { get; set; }
+}
+
+public sealed class UserInterfaceSettings
+{
+    public string? Language { get; set; }
+
+    public double? FrameIntervalSeconds { get; set; }
+
+    public string? OutputRootDirectory { get; set; }
+
+    public MainWindowLaunchSettings? MainWindow { get; set; }
+}
+
+public sealed class MainWindowLaunchSettings
+{
+    public int? Width { get; set; }
+
+    public int? Height { get; set; }
 }

--- a/src/MovieTelopTranscriber.App/Services/AppLaunchSettingsLoader.cs
+++ b/src/MovieTelopTranscriber.App/Services/AppLaunchSettingsLoader.cs
@@ -11,32 +11,33 @@ internal static class AppLaunchSettingsLoader
     private const string InstallManifestFileName = "movie-telop-transcriber.installation.json";
     private const string InstallerCommandFileName = "Install-MovieTelopTranscriber.cmd";
 
-    public static void Apply()
+    public static AppLaunchSettingsLoadResult Load()
     {
         var settingsPath = FindSettingsPath();
         if (settingsPath is null)
         {
-            return;
+            return new AppLaunchSettingsLoadResult(null, new AppLaunchSettings(), null);
         }
 
-        AppLaunchSettings? settings;
         try
         {
             using var stream = File.OpenRead(settingsPath);
             using var document = JsonDocument.Parse(stream);
-            settings = ParseSettings(document.RootElement);
+            return new AppLaunchSettingsLoadResult(settingsPath, ParseSettings(document.RootElement), null);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
         {
+            return new AppLaunchSettingsLoadResult(settingsPath, new AppLaunchSettings(), ex.Message);
+        }
+    }
+
+    public static void Apply(AppLaunchSettings settings, string? settingsPath, string? loadError)
+    {
+        if (!string.IsNullOrWhiteSpace(loadError) && !string.IsNullOrWhiteSpace(settingsPath))
+        {
             Environment.SetEnvironmentVariable(
                 "MOVIE_TELOP_LAUNCH_SETTINGS_LOAD_ERROR",
-                $"{settingsPath}: {ex.Message}");
-            return;
-        }
-
-        if (settings is null)
-        {
-            return;
+                $"{settingsPath}: {loadError}");
         }
 
         SetString("MOVIE_TELOP_OCR_ENGINE", settings.OcrEngine);
@@ -65,7 +66,152 @@ internal static class AppLaunchSettingsLoader
         SetDouble("MOVIE_TELOP_PADDLEOCR_MIN_TEXT_SIZE", settings.PaddleOcr.MinTextSize);
     }
 
-    private static void SetPath(string environmentVariable, string? value, string settingsPath)
+    public static void Save(AppLaunchSettings settings, string? preferredSettingsPath = null)
+    {
+        var settingsPath = ResolveWritableSettingsPath(preferredSettingsPath);
+        var settingsDirectory = Path.GetDirectoryName(settingsPath);
+        if (!string.IsNullOrWhiteSpace(settingsDirectory))
+        {
+            Directory.CreateDirectory(settingsDirectory);
+        }
+
+        var normalized = NormalizeForSave(settings, settingsPath);
+        var json = JsonSerializer.Serialize(normalized, AppSettingsJsonContext.Default.AppLaunchSettings);
+
+        File.WriteAllText(settingsPath, json);
+    }
+
+    public static string? FindSettingsPath()
+    {
+        var baseSettingsPath = Path.Combine(AppContext.BaseDirectory, SettingsFileName);
+        if (File.Exists(baseSettingsPath))
+        {
+            return baseSettingsPath;
+        }
+
+        var baseDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        if (!string.Equals(baseDirectory.Name, "app", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var packageRoot = baseDirectory.Parent;
+        if (packageRoot is null)
+        {
+            return null;
+        }
+
+        var installerCommandPath = Path.Combine(packageRoot.FullName, InstallerCommandFileName);
+        if (!File.Exists(installerCommandPath))
+        {
+            return null;
+        }
+
+        var siblingInstallRoot = Path.Combine(packageRoot.FullName, InstallRootName);
+        var siblingManifestPath = Path.Combine(siblingInstallRoot, InstallManifestFileName);
+        var siblingSettingsPath = Path.Combine(siblingInstallRoot, "app", SettingsFileName);
+        if (File.Exists(siblingManifestPath) && File.Exists(siblingSettingsPath))
+        {
+            return siblingSettingsPath;
+        }
+
+        return null;
+    }
+
+    private static string ResolveWritableSettingsPath(string? preferredSettingsPath)
+    {
+        if (!string.IsNullOrWhiteSpace(preferredSettingsPath))
+        {
+            return Path.GetFullPath(preferredSettingsPath);
+        }
+
+        var discovered = FindSettingsPath();
+        if (!string.IsNullOrWhiteSpace(discovered))
+        {
+            return discovered;
+        }
+
+        return Path.Combine(AppContext.BaseDirectory, SettingsFileName);
+    }
+
+    private static AppLaunchSettings NormalizeForSave(AppLaunchSettings settings, string settingsPath)
+    {
+        return new AppLaunchSettings
+        {
+            OcrEngine = NormalizeString(settings.OcrEngine),
+            OcrWorkerPath = NormalizeRelativePath(settings.OcrWorkerPath, settingsPath),
+            PaddleOcr = settings.PaddleOcr is null
+                ? null
+                : new PaddleOcrLaunchSettings
+                {
+                    PythonPath = NormalizeRelativePath(settings.PaddleOcr.PythonPath, settingsPath),
+                    ScriptPath = NormalizeRelativePath(settings.PaddleOcr.ScriptPath, settingsPath),
+                    Device = NormalizeString(settings.PaddleOcr.Device),
+                    Language = NormalizeString(settings.PaddleOcr.Language),
+                    MinScore = settings.PaddleOcr.MinScore,
+                    NormalizeSmallKana = settings.PaddleOcr.NormalizeSmallKana,
+                    Preprocess = settings.PaddleOcr.Preprocess,
+                    Contrast = settings.PaddleOcr.Contrast,
+                    Sharpen = settings.PaddleOcr.Sharpen,
+                    TextDetThresh = settings.PaddleOcr.TextDetThresh,
+                    TextDetBoxThresh = settings.PaddleOcr.TextDetBoxThresh,
+                    TextDetUnclipRatio = settings.PaddleOcr.TextDetUnclipRatio,
+                    TextDetLimitSideLen = settings.PaddleOcr.TextDetLimitSideLen,
+                    UseTextlineOrientation = settings.PaddleOcr.UseTextlineOrientation,
+                    UseDocUnwarping = settings.PaddleOcr.UseDocUnwarping,
+                    MinTextSize = settings.PaddleOcr.MinTextSize
+                },
+            Ui = settings.Ui is null
+                ? null
+                : new UserInterfaceSettings
+                {
+                    Language = NormalizeString(settings.Ui.Language),
+                    FrameIntervalSeconds = settings.Ui.FrameIntervalSeconds,
+                    OutputRootDirectory = NormalizeRelativePath(settings.Ui.OutputRootDirectory, settingsPath),
+                    MainWindow = settings.Ui.MainWindow is null
+                        ? null
+                        : new MainWindowLaunchSettings
+                        {
+                            Width = settings.Ui.MainWindow.Width,
+                            Height = settings.Ui.MainWindow.Height
+                        }
+                }
+        };
+    }
+
+    private static string? NormalizeRelativePath(string? value, string settingsPath)
+    {
+        var normalized = NormalizeString(value);
+        if (normalized is null)
+        {
+            return null;
+        }
+
+        var expanded = Environment.ExpandEnvironmentVariables(normalized);
+        if (!Path.IsPathRooted(expanded))
+        {
+            return normalized;
+        }
+
+        var settingsDirectory = Path.GetDirectoryName(settingsPath);
+        if (string.IsNullOrWhiteSpace(settingsDirectory))
+        {
+            return Path.GetFullPath(expanded);
+        }
+
+        var fullPath = Path.GetFullPath(expanded);
+        var relativePath = Path.GetRelativePath(settingsDirectory, fullPath);
+        return relativePath.StartsWith("..", StringComparison.Ordinal)
+            ? fullPath
+            : relativePath;
+    }
+
+    private static string? NormalizeString(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static void SetPath(string environmentVariable, string? value, string? settingsPath)
     {
         if (string.IsNullOrWhiteSpace(value))
         {
@@ -120,44 +266,7 @@ internal static class AppLaunchSettingsLoader
             value.Value.ToString(CultureInfo.InvariantCulture));
     }
 
-    private static string? FindSettingsPath()
-    {
-        var baseSettingsPath = Path.Combine(AppContext.BaseDirectory, SettingsFileName);
-        if (File.Exists(baseSettingsPath))
-        {
-            return baseSettingsPath;
-        }
-
-        var baseDirectory = new DirectoryInfo(AppContext.BaseDirectory);
-        if (!string.Equals(baseDirectory.Name, "app", StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
-
-        var packageRoot = baseDirectory.Parent;
-        if (packageRoot is null)
-        {
-            return null;
-        }
-
-        var installerCommandPath = Path.Combine(packageRoot.FullName, InstallerCommandFileName);
-        if (!File.Exists(installerCommandPath))
-        {
-            return null;
-        }
-
-        var siblingInstallRoot = Path.Combine(packageRoot.FullName, InstallRootName);
-        var siblingManifestPath = Path.Combine(siblingInstallRoot, InstallManifestFileName);
-        var siblingSettingsPath = Path.Combine(siblingInstallRoot, "app", SettingsFileName);
-        if (File.Exists(siblingManifestPath) && File.Exists(siblingSettingsPath))
-        {
-            return siblingSettingsPath;
-        }
-
-        return null;
-    }
-
-    private static string ResolvePath(string value, string settingsPath)
+    private static string ResolvePath(string value, string? settingsPath)
     {
         var expanded = Environment.ExpandEnvironmentVariables(value);
         if (Path.IsPathRooted(expanded))
@@ -165,7 +274,12 @@ internal static class AppLaunchSettingsLoader
             return Path.GetFullPath(expanded);
         }
 
-        var settingsDirectory = Path.GetDirectoryName(settingsPath) ?? AppContext.BaseDirectory;
+        var settingsDirectory = Path.GetDirectoryName(settingsPath ?? string.Empty);
+        if (string.IsNullOrWhiteSpace(settingsDirectory))
+        {
+            return Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, expanded));
+        }
+
         return Path.GetFullPath(Path.Combine(settingsDirectory, expanded));
     }
 
@@ -194,6 +308,21 @@ internal static class AppLaunchSettingsLoader
                     UseTextlineOrientation = ReadBool(paddle, "useTextlineOrientation"),
                     UseDocUnwarping = ReadBool(paddle, "useDocUnwarping"),
                     MinTextSize = ReadDouble(paddle, "minTextSize")
+                }
+                : null,
+            Ui = ReadObject(root, "ui") is { } ui
+                ? new UserInterfaceSettings
+                {
+                    Language = ReadString(ui, "language"),
+                    FrameIntervalSeconds = ReadDouble(ui, "frameIntervalSeconds"),
+                    OutputRootDirectory = ReadString(ui, "outputRootDirectory"),
+                    MainWindow = ReadObject(ui, "mainWindow") is { } mainWindow
+                        ? new MainWindowLaunchSettings
+                        {
+                            Width = ReadInt(mainWindow, "width"),
+                            Height = ReadInt(mainWindow, "height")
+                        }
+                        : null
                 }
                 : null
         };
@@ -273,3 +402,8 @@ internal static class AppLaunchSettingsLoader
         return false;
     }
 }
+
+internal sealed record AppLaunchSettingsLoadResult(
+    string? SettingsPath,
+    AppLaunchSettings Settings,
+    string? LoadError);

--- a/src/MovieTelopTranscriber.App/Services/AppSettingsJsonContext.cs
+++ b/src/MovieTelopTranscriber.App/Services/AppSettingsJsonContext.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+using MovieTelopTranscriber.App.Models;
+
+namespace MovieTelopTranscriber.App.Services;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(AppLaunchSettings))]
+[JsonSerializable(typeof(MainWindowLaunchSettings))]
+[JsonSerializable(typeof(PaddleOcrLaunchSettings))]
+[JsonSerializable(typeof(UserInterfaceSettings))]
+internal sealed partial class AppSettingsJsonContext : JsonSerializerContext
+{
+}

--- a/src/MovieTelopTranscriber.App/Services/MainWindowLayoutStore.cs
+++ b/src/MovieTelopTranscriber.App/Services/MainWindowLayoutStore.cs
@@ -1,4 +1,5 @@
 using Windows.Graphics;
+using MovieTelopTranscriber.App.Models;
 
 namespace MovieTelopTranscriber.App.Services;
 
@@ -12,6 +13,14 @@ internal static class MainWindowLayoutStore
 
     public static SizeInt32 LoadOrDefault()
     {
+        var savedLayout = App.LaunchSettings.Ui?.MainWindow;
+        if (savedLayout?.Width is > 0 && savedLayout.Height is > 0)
+        {
+            return new SizeInt32(
+                Math.Max(MinimumWidth, savedLayout.Width.Value),
+                Math.Max(MinimumHeight, savedLayout.Height.Value));
+        }
+
         try
         {
             var path = GetLayoutFilePath();
@@ -45,15 +54,13 @@ internal static class MainWindowLayoutStore
         {
             var width = Math.Max(MinimumWidth, size.Width);
             var height = Math.Max(MinimumHeight, size.Height);
-            var path = GetLayoutFilePath();
-            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-            var json = $$"""
-                {
-                  "width": {{width}},
-                  "height": {{height}}
-                }
-                """;
-            File.WriteAllText(path, json);
+            App.LaunchSettings.Ui ??= new UserInterfaceSettings();
+            App.LaunchSettings.Ui.MainWindow = new MainWindowLaunchSettings
+            {
+                Width = width,
+                Height = height
+            };
+            AppLaunchSettingsLoader.Save(App.LaunchSettings, App.LaunchSettingsPath);
         }
         catch
         {

--- a/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
+++ b/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
@@ -75,6 +75,7 @@ public partial class MainPageViewModel : ObservableObject
     private int _manualEditSequence;
     private Task<OcrWorkerWarmupResult>? _pendingOcrWarmupTask;
     private string? _pendingOcrWarmupSettingsSignature;
+    private bool _settingsPersistenceReady;
 
     public MainPageViewModel()
     {
@@ -86,10 +87,12 @@ public partial class MainPageViewModel : ObservableObject
         PreviewDetections = new ObservableCollection<PreviewDetectionOverlay>();
 
         SelectedLanguageOption = ResolveDefaultLanguageOption();
+        ApplySavedUserInterfaceSettings();
         UiText = LocalizedUiText.ForLanguage(SelectedLanguageOption.Code);
         ApplyPaddleOcrEnvironment();
         RefreshStaticCollections();
         ResetDynamicCollections();
+        _settingsPersistenceReady = true;
     }
 
     public ObservableCollection<SettingItem> SettingItems { get; }
@@ -333,102 +336,121 @@ public partial class MainPageViewModel : ObservableObject
     {
         FrameIntervalText = FormatSettingNumber(value, "0.##");
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnFrameIntervalTextChanged(string value)
     {
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleContrastValueChanged(double value)
     {
         PaddleContrastText = FormatSettingNumber(value, "0.##");
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnOutputRootDirectoryTextChanged(string value)
     {
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddlePreprocessEnabledChanged(bool value)
     {
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleContrastTextChanged(string value)
     {
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleSharpenEnabledChanged(bool value)
     {
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleTextDetThreshTextChanged(string value)
     {
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleTextDetThreshValueChanged(double value)
     {
         PaddleTextDetThreshText = FormatSettingNumber(value, "0.##");
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleTextDetBoxThreshTextChanged(string value)
     {
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleTextDetBoxThreshValueChanged(double value)
     {
         PaddleTextDetBoxThreshText = FormatSettingNumber(value, "0.##");
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleTextDetUnclipRatioTextChanged(string value)
     {
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleTextDetUnclipRatioValueChanged(double value)
     {
         PaddleTextDetUnclipRatioText = FormatSettingNumber(value, "0.#");
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleTextDetLimitSideLenTextChanged(string value)
     {
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleTextDetLimitSideLenValueChanged(double value)
     {
         PaddleTextDetLimitSideLenText = Math.Round(value).ToString(CultureInfo.InvariantCulture);
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleMinTextSizeTextChanged(string value)
     {
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleMinTextSizeValueChanged(double value)
     {
         PaddleMinTextSizeText = FormatSettingNumber(value, "0.#");
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleUseTextlineOrientationChanged(bool value)
     {
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnPaddleUseDocUnwarpingChanged(bool value)
     {
         RefreshStaticCollections();
+        OnUserSettingsChanged();
     }
 
     partial void OnSelectedLanguageOptionChanged(LanguageOption value)
@@ -441,6 +463,7 @@ public partial class MainPageViewModel : ObservableObject
             _latestFrameExtractionResult?.Frames.Count ?? 0,
             _latestFrameAnalyses.Sum(analysis => analysis.Attributes.Detections.Count),
             _latestSegments.Count);
+        OnUserSettingsChanged();
     }
 
     [RelayCommand]
@@ -2611,6 +2634,78 @@ public partial class MainPageViewModel : ObservableObject
             : DefaultFrameIntervalSeconds;
     }
 
+    private void ApplySavedUserInterfaceSettings()
+    {
+        var uiSettings = App.LaunchSettings.Ui;
+        if (uiSettings is null)
+        {
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(uiSettings.Language))
+        {
+            var savedLanguage = LanguageOptions.FirstOrDefault(option =>
+                string.Equals(option.Code, uiSettings.Language, StringComparison.OrdinalIgnoreCase));
+            if (savedLanguage is not null)
+            {
+                SelectedLanguageOption = savedLanguage;
+            }
+        }
+
+        if (uiSettings.FrameIntervalSeconds is > 0)
+        {
+            FrameIntervalValue = uiSettings.FrameIntervalSeconds.Value;
+            FrameIntervalText = FormatSettingNumber(uiSettings.FrameIntervalSeconds.Value, "0.##");
+        }
+
+        if (!string.IsNullOrWhiteSpace(uiSettings.OutputRootDirectory))
+        {
+            OutputRootDirectoryText = ResolveSavedPath(uiSettings.OutputRootDirectory);
+        }
+    }
+
+    private void PersistUserSettings()
+    {
+        if (!_settingsPersistenceReady)
+        {
+            return;
+        }
+
+        App.LaunchSettings.OcrEngine ??= Environment.GetEnvironmentVariable("MOVIE_TELOP_OCR_ENGINE") ?? "paddleocr";
+        App.LaunchSettings.OcrWorkerPath = Environment.GetEnvironmentVariable("MOVIE_TELOP_OCR_WORKER");
+        App.LaunchSettings.PaddleOcr ??= new PaddleOcrLaunchSettings();
+        App.LaunchSettings.PaddleOcr.PythonPath = Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_PYTHON");
+        App.LaunchSettings.PaddleOcr.ScriptPath = Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_SCRIPT");
+        App.LaunchSettings.PaddleOcr.Device = Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_DEVICE");
+        App.LaunchSettings.PaddleOcr.Language = Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_LANG");
+        App.LaunchSettings.PaddleOcr.MinScore = ReadEnvironmentDouble("MOVIE_TELOP_PADDLEOCR_MIN_SCORE");
+        App.LaunchSettings.PaddleOcr.NormalizeSmallKana = ReadEnvironmentBool("MOVIE_TELOP_PADDLEOCR_NORMALIZE_SMALL_KANA");
+        App.LaunchSettings.PaddleOcr.Preprocess = PaddlePreprocessEnabled;
+        App.LaunchSettings.PaddleOcr.Contrast = ParseOptionalDouble(PaddleContrastText, 0.1d, 4.0d);
+        App.LaunchSettings.PaddleOcr.Sharpen = PaddleSharpenEnabled;
+        App.LaunchSettings.PaddleOcr.TextDetThresh = ParseOptionalDouble(PaddleTextDetThreshText, 0.0d, 1.0d);
+        App.LaunchSettings.PaddleOcr.TextDetBoxThresh = ParseOptionalDouble(PaddleTextDetBoxThreshText, 0.0d, 1.0d);
+        App.LaunchSettings.PaddleOcr.TextDetUnclipRatio = ParseOptionalDouble(PaddleTextDetUnclipRatioText, 0.1d, 10.0d);
+        App.LaunchSettings.PaddleOcr.TextDetLimitSideLen = ParseOptionalInt(PaddleTextDetLimitSideLenText, 16, 4096);
+        App.LaunchSettings.PaddleOcr.MinTextSize = ParseOptionalDouble(PaddleMinTextSizeText, 0.0d, 200.0d);
+        App.LaunchSettings.PaddleOcr.UseTextlineOrientation = PaddleUseTextlineOrientation;
+        App.LaunchSettings.PaddleOcr.UseDocUnwarping = PaddleUseDocUnwarping;
+
+        App.LaunchSettings.Ui ??= new UserInterfaceSettings();
+        App.LaunchSettings.Ui.Language = SelectedLanguageOption.Code;
+        App.LaunchSettings.Ui.FrameIntervalSeconds = ParseFrameIntervalSeconds();
+        App.LaunchSettings.Ui.OutputRootDirectory = string.IsNullOrWhiteSpace(OutputRootDirectoryText)
+            ? null
+            : OutputRootDirectoryText.Trim();
+
+        AppLaunchSettingsLoader.Save(App.LaunchSettings, App.LaunchSettingsPath);
+    }
+
+    private void OnUserSettingsChanged()
+    {
+        PersistUserSettings();
+    }
+
     private void ApplyPaddleOcrEnvironment()
     {
         SetEnvironment(PaddlePreprocessEnvironmentVariable, PaddlePreprocessEnabled ? "true" : "false");
@@ -2696,12 +2791,36 @@ public partial class MainPageViewModel : ObservableObject
         return string.IsNullOrWhiteSpace(value) ? defaultValue : value;
     }
 
+    private static double? ReadEnvironmentDouble(string name)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+
     private static double ReadDoubleSetting(string name, double defaultValue)
     {
         var value = Environment.GetEnvironmentVariable(name);
         return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
             ? parsed
             : defaultValue;
+    }
+
+    private static bool? ReadEnvironmentBool(string name)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "1" or "true" or "yes" or "on" => true,
+            "0" or "false" or "no" or "off" => false,
+            _ => null
+        };
     }
 
     private static bool ReadBoolEnvironment(string name, bool defaultValue)
@@ -2746,6 +2865,49 @@ public partial class MainPageViewModel : ObservableObject
     private static void SetEnvironment(string name, string? value)
     {
         Environment.SetEnvironmentVariable(name, value, EnvironmentVariableTarget.Process);
+    }
+
+    private static double? ParseOptionalDouble(string text, double minimum, double maximum)
+    {
+        if (!double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
+        {
+            return null;
+        }
+
+        return Math.Clamp(value, minimum, maximum);
+    }
+
+    private static int? ParseOptionalInt(string text, int minimum, int maximum)
+    {
+        if (!int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+        {
+            return null;
+        }
+
+        return Math.Clamp(value, minimum, maximum);
+    }
+
+    private static string ResolveSavedPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return path;
+        }
+
+        var settingsPath = App.LaunchSettingsPath;
+        if (string.IsNullOrWhiteSpace(settingsPath))
+        {
+            return Path.GetFullPath(Environment.ExpandEnvironmentVariables(path));
+        }
+
+        var expanded = Environment.ExpandEnvironmentVariables(path);
+        if (Path.IsPathRooted(expanded))
+        {
+            return Path.GetFullPath(expanded);
+        }
+
+        var settingsDirectory = Path.GetDirectoryName(settingsPath) ?? AppContext.BaseDirectory;
+        return Path.GetFullPath(Path.Combine(settingsDirectory, expanded));
     }
 
     private static LanguageOption ResolveDefaultLanguageOption()

--- a/tools/install/Install-MovieTelopTranscriber.ps1
+++ b/tools/install/Install-MovieTelopTranscriber.ps1
@@ -168,6 +168,15 @@ function Write-AppLaunchSettings {
             contrast = 1.1
             sharpen = $true
         }
+        ui = [ordered]@{
+            language = "ja"
+            frameIntervalSeconds = 1.0
+            outputRootDirectory = ".\\work\\runs"
+            mainWindow = [ordered]@{
+                width = 1820
+                height = 1080
+            }
+        }
     }
 
     $json = $settingsObject | ConvertTo-Json -Depth 5


### PR DESCRIPTION
## 概要
- `movie-telop-transcriber.settings.json` を利用者設定の正本として拡張
- UI 変更時に同じ JSON へ保存し、次回起動時に同じ JSON から読み戻す構成へ整理
- 設定仕様書と検証記録を追加

## 変更内容
- `ui` セクションを追加し、言語、抽出間隔、出力先、メイン画面サイズを保存対象に追加
- OCR 設定保存と UI 設定保存を同じ `movie-telop-transcriber.settings.json` に統合
- 旧 `main-window-layout.json` は fallback としてのみ扱う構成へ変更
- インストーラが生成する settings JSON に `ui` 初期値を追加
- `docs/14_設定ファイル仕様.md` と検証レポートを追加

## 検証
- `dotnet build src\MovieTelopTranscriber.sln -c Release -p:Platform=x64`
- `git diff --check`
- build 結果: 0 warnings / 0 errors

## 補足
- WinUI の手動操作確認は今回未実施で、コード経路と build を中心に確認