### PR TITLE
Evaluate GPU OCR 2-worker performance

### DIFF
--- a/docs/test-results/2026-04-29_issue158_gpu_worker_evaluation.md
+++ b/docs/test-results/2026-04-29_issue158_gpu_worker_evaluation.md
@@ -1,0 +1,81 @@
+# Issue 158 GPU 環境での OCR 2 worker 再評価
+
+## 概要
+- 対象 Issue: `#158`
+- 計測日: 2026-04-29
+- 目的: GPU 環境で `paddleocr` の 2 worker 並列を再評価し、設定項目として公開する価値があるか判断する。
+
+## 環境
+- GPU: `NVIDIA GeForce RTX 2070 SUPER`
+- driver: `591.59`
+- NVIDIA 表示上の CUDA version: `13.1`
+- Python: `3.10`
+- PaddlePaddle: `paddlepaddle-gpu==3.2.2`
+- PaddleOCR: `3.5.0`
+- paddlex: `3.5.1`
+- device: `gpu:0`
+
+## インストール条件
+- GPU 用の検証は CPU 用 venv と分離し、`temp/ocr-eval-gpu/.venv` を新規作成した。
+- PaddlePaddle の GPU wheel は公式 Windows pip ドキュメントに従い `cu126` 向けの `paddlepaddle-gpu==3.2.2` を使用した。
+- 検証用 benchmark は `tools/validation/OcrWorkerModeBenchmark` を拡張し、以下を記録するようにした。
+  - `MOVIE_TELOP_PADDLEOCR_DEVICE`
+  - 実行 worker 数
+  - warmup 時間
+  - OCR wall-clock
+  - `nvidia-smi` による GPU utilization / VRAM 使用量サンプル
+
+## 計測対象
+1. `test-data/basic_telop/botirist.mp4`
+   - 先頭 40 フレーム
+   - `#152` の CPU 評価と比較しやすい条件
+2. `test-data/benchmark_suite/sample_basic_telop_60s.mp4`
+   - 先頭 60 フレーム
+   - 現行 benchmark suite の中尺サンプル
+
+## 計測結果
+
+### 1. `botirist.mp4` 40 フレーム
+| モード | worker 数 | wall-clock ms | warmup 合計 ms | worker execution 合計 ms | GPU util max | GPU util avg | VRAM max MiB | error |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 単一 worker | 1 | 6,533.0 | 12,303.5 | 6,261.3 | 43 | 17.4 | 5,760 | 0 |
+| 2 workers | 2 | 4,115.8 | 24,455.2 | 7,914.3 | 74 | 22.8 | 6,851 | 0 |
+
+- wall-clock は `6.53s -> 4.12s` で約 `37.0%` 短縮
+- warmup は `12.30s -> 24.46s` で約 `99%` 増加
+- VRAM peak は `5,760 MiB -> 6,851 MiB` で約 `+1.1 GiB`
+
+### 2. `sample_basic_telop_60s.mp4` 60 フレーム
+| モード | worker 数 | wall-clock ms | warmup 合計 ms | worker execution 合計 ms | GPU util max | GPU util avg | VRAM max MiB | error |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 単一 worker | 1 | 7,647.9 | 11,598.4 | 7,144.1 | 51 | 21.3 | 5,109 | 0 |
+| 2 workers | 2 | 5,728.2 | 22,934.8 | 10,758.3 | 86 | 31.6 | 6,246 | 0 |
+
+- wall-clock は `7.65s -> 5.73s` で約 `25.1%` 短縮
+- warmup は `11.60s -> 22.93s` で約 `97.7%` 増加
+- VRAM peak は `5,109 MiB -> 6,246 MiB` で約 `+1.1 GiB`
+
+## CPU 評価との比較
+- `#152` の CPU 評価では `botirist.mp4` 40 フレームで `73.3s -> 62.1s` の約 `15.4%` 短縮だった。
+- 同条件の GPU 評価では `6.53s -> 4.12s` の約 `37.0%` 短縮となり、2 worker の改善幅が明確に大きい。
+- 一方で GPU でも worker execution 合計と warmup は増加するため、「常に得」ではない。
+
+## 観察
+1. GPU 環境では 2 workers の wall-clock 改善が CPU より大きい。
+2. VRAM は 2 workers で約 1.1 GiB 追加で必要になる。
+3. RTX 2070 SUPER 8GB では 2 workers が成立したが、常駐アプリ込みで `6.2GB - 6.9GB` 付近まで上がる。
+4. GPU utilization は 2 workers の方が高く、単一 worker より GPU を使い切れている。
+5. warmup は worker 数にほぼ比例して重くなり、単発実行では体感改善を打ち消す可能性がある。
+
+## 判断
+- GPU 環境では 2 workers 並列は採用価値がある。
+- ただし既定値として常時有効にするのは避ける。
+  - GPU 非搭載環境では意味がない
+  - 8GB 級 GPU では VRAM 余裕が大きくない
+  - warmup が約 2 倍になる
+- 結論として、`GPU 利用時のみ選べる任意設定` として検討するのが妥当。
+
+## 次アクション案
+1. アプリ設定に `OCR worker 数` を追加し、GPU 利用時のみ `1` / `2` を選べるようにする。
+2. 既定値は `1` のままにし、ヘルプテキストで「GPU 環境では 2 が速い場合があるが VRAM 消費が増える」と明記する。
+3. 起動時 warmup が支配的なため、設定化する場合は `#154` の前倒し warmup と組み合わせる前提で扱う。

--- a/tools/validation/OcrWorkerModeBenchmark/Program.cs
+++ b/tools/validation/OcrWorkerModeBenchmark/Program.cs
@@ -1,34 +1,50 @@
 using MovieTelopTranscriber.App.Models;
 using MovieTelopTranscriber.App.Services;
 using System.Diagnostics;
+using System.Globalization;
 using System.Text.Json;
 
 var repoRoot = ResolveRepoRoot();
-ConfigurePaddleOcrEnvironment(repoRoot);
+var options = BenchmarkOptions.Parse(args, repoRoot);
+ConfigurePaddleOcrEnvironment(options, repoRoot);
 
 var videoService = new OpenCvVideoProcessingService();
-var benchmarkRoot = Path.Combine(repoRoot, "temp", "issue152-benchmark-runs");
-Directory.CreateDirectory(benchmarkRoot);
+Directory.CreateDirectory(options.BenchmarkRoot);
 
-var videoPath = Path.Combine(repoRoot, "test-data", "basic_telop", "botirist.mp4");
-var metadata = await videoService.ReadMetadataAsync(videoPath);
-var extraction = await videoService.ExtractFramesAsync(metadata, 1.0d, null, benchmarkRoot);
-var targetFrames = extraction.Frames.Take(40).ToArray();
-
-var results = new List<BenchmarkResult>
+var metadata = await videoService.ReadMetadataAsync(options.VideoPath);
+var extraction = await videoService.ExtractFramesAsync(metadata, 1.0d, null, options.BenchmarkRoot);
+var targetFrames = extraction.Frames.Take(options.FrameCount).ToArray();
+if (targetFrames.Length == 0)
 {
-    await BenchmarkAsync("single_worker_serial", targetFrames, workerCount: 1),
-    await BenchmarkAsync("two_workers_parallel", targetFrames, workerCount: 2),
-    await BenchmarkAsync("three_workers_parallel", targetFrames, workerCount: 3)
-};
+    throw new InvalidOperationException("No frames were extracted for benchmark.");
+}
 
-Console.WriteLine(JsonSerializer.Serialize(results, new JsonSerializerOptions
+var probe = await NvidaSmiProbe.TryCollectOnceAsync();
+var results = new List<BenchmarkResult>();
+foreach (var workerCount in options.WorkerCounts)
+{
+    results.Add(await BenchmarkAsync(options, targetFrames, workerCount));
+}
+
+var report = new BenchmarkReport(
+    DateTimeOffset.Now,
+    probe,
+    new BenchmarkEnvironment(
+        options.Device,
+        Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_PYTHON") ?? string.Empty,
+        Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_SCRIPT") ?? string.Empty,
+        targetFrames.Length,
+        options.VideoPath,
+        options.BenchmarkRoot),
+    results);
+
+Console.WriteLine(JsonSerializer.Serialize(report, new JsonSerializerOptions
 {
     WriteIndented = true
 }));
 
 static async Task<BenchmarkResult> BenchmarkAsync(
-    string modeName,
+    BenchmarkOptions options,
     IReadOnlyList<ExtractedFrameRecord> frames,
     int workerCount)
 {
@@ -39,12 +55,19 @@ static async Task<BenchmarkResult> BenchmarkAsync(
     try
     {
         var benchmarkDirectory = Path.Combine(
-            ResolveRepoRoot(),
-            "temp",
-            "issue152-worker-bench",
-            modeName,
+            options.BenchmarkRoot,
+            $"{workerCount:D2}-workers",
             Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(benchmarkDirectory);
+
+        await using var sampler = NvidaSmiSampler.IsAvailable()
+            ? new NvidaSmiSampler(TimeSpan.FromMilliseconds(500))
+            : null;
+
+        if (sampler is not null)
+        {
+            await sampler.StartAsync();
+        }
 
         var warmupTasks = clients
             .Select((client, index) => client.WarmupAsync(Path.Combine(benchmarkDirectory, $"worker-{index + 1:D2}")))
@@ -64,6 +87,11 @@ static async Task<BenchmarkResult> BenchmarkAsync(
         var partitions = await Task.WhenAll(workerTasks);
         wallClock.Stop();
 
+        if (sampler is not null)
+        {
+            await sampler.StopAsync();
+        }
+
         foreach (var partition in partitions)
         {
             perFrameResults.AddRange(partition);
@@ -71,7 +99,6 @@ static async Task<BenchmarkResult> BenchmarkAsync(
 
         var ordered = perFrameResults.OrderBy(result => result.TimestampMs).ToArray();
         return new BenchmarkResult(
-            modeName,
             workerCount,
             frames.Count,
             Math.Round(wallClock.Elapsed.TotalMilliseconds, 1),
@@ -81,7 +108,8 @@ static async Task<BenchmarkResult> BenchmarkAsync(
             Math.Round(ordered.Average(item => item.TotalMs), 1),
             Math.Round(ordered.Max(item => item.TotalMs), 1),
             ordered.Count(item => string.Equals(item.Status, "success", StringComparison.OrdinalIgnoreCase)),
-            ordered.Count(item => string.Equals(item.Status, "error", StringComparison.OrdinalIgnoreCase)));
+            ordered.Count(item => string.Equals(item.Status, "error", StringComparison.OrdinalIgnoreCase)),
+            sampler?.BuildSummary());
     }
     finally
     {
@@ -106,7 +134,7 @@ static async Task<IReadOnlyList<FrameModeResult>> RunWorkerPartitionAsync(
     {
         var frame = frames[frameIndex];
         var request = new OcrWorkerRequest(
-            $"issue152-{workerIndex + 1:D2}-{frame.FrameIndex:D6}-{frame.TimestampMs:D8}ms",
+            $"issue158-{workerIndex + 1:D2}-{frame.FrameIndex:D6}-{frame.TimestampMs:D8}ms",
             frame.FrameIndex,
             frame.TimestampMs,
             frame.ImagePath,
@@ -144,12 +172,12 @@ static string ResolveRepoRoot()
     throw new InvalidOperationException("Repository root could not be resolved.");
 }
 
-static void ConfigurePaddleOcrEnvironment(string repoRoot)
+static void ConfigurePaddleOcrEnvironment(BenchmarkOptions options, string repoRoot)
 {
     Environment.SetEnvironmentVariable("MOVIE_TELOP_OCR_ENGINE", "paddleocr");
-    Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_PYTHON", Path.Combine(repoRoot, "temp", "ocr-eval", ".venv", "Scripts", "python.exe"));
+    Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_PYTHON", options.PythonPath);
     Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_SCRIPT", Path.Combine(repoRoot, "tools", "ocr", "paddle_ocr_worker.py"));
-    Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_DEVICE", "cpu");
+    Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_DEVICE", options.Device);
     Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_LANG", "ja");
     Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_MIN_SCORE", "0.5");
     Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_NORMALIZE_SMALL_KANA", "true");
@@ -158,15 +186,97 @@ static void ConfigurePaddleOcrEnvironment(string repoRoot)
     Environment.SetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_SHARPEN", "true");
 }
 
-sealed record FrameModeResult(
-    int FrameIndex,
-    long TimestampMs,
-    string Status,
-    double TotalMs,
-    double WorkerExecutionMs);
+sealed record BenchmarkOptions(
+    string PythonPath,
+    string Device,
+    string VideoPath,
+    int FrameCount,
+    string BenchmarkRoot,
+    IReadOnlyList<int> WorkerCounts)
+{
+    public static BenchmarkOptions Parse(string[] args, string repoRoot)
+    {
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var index = 0; index < args.Length; index++)
+        {
+            var arg = args[index];
+            if (!arg.StartsWith("--", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var key = arg[2..];
+            var value = index + 1 < args.Length && !args[index + 1].StartsWith("--", StringComparison.Ordinal)
+                ? args[++index]
+                : "true";
+            values[key] = value;
+        }
+
+        var pythonPath = values.TryGetValue("python", out var configuredPython)
+            ? configuredPython
+            : Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_PYTHON");
+        if (string.IsNullOrWhiteSpace(pythonPath))
+        {
+            pythonPath = Path.Combine(repoRoot, "temp", "ocr-eval-gpu", ".venv", "Scripts", "python.exe");
+        }
+
+        var device = values.TryGetValue("device", out var configuredDevice)
+            ? configuredDevice
+            : Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_DEVICE");
+        if (string.IsNullOrWhiteSpace(device))
+        {
+            device = "gpu:0";
+        }
+
+        var videoPath = values.TryGetValue("video", out var configuredVideo)
+            ? configuredVideo
+            : Path.Combine(repoRoot, "test-data", "benchmark_suite", "sample_basic_telop_60s.mp4");
+
+        var frameCount = values.TryGetValue("frames", out var configuredFrames)
+            && int.TryParse(configuredFrames, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedFrames)
+            && parsedFrames > 0
+            ? parsedFrames
+            : 60;
+
+        var benchmarkRoot = values.TryGetValue("output", out var configuredOutput)
+            ? configuredOutput
+            : Path.Combine(repoRoot, "temp", "issue158-gpu-worker-bench");
+
+        var workerCounts = values.TryGetValue("workers", out var configuredWorkers)
+            ? configuredWorkers
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(value => int.Parse(value, CultureInfo.InvariantCulture))
+                .Where(value => value > 0)
+                .Distinct()
+                .Order()
+                .ToArray()
+            : [1, 2];
+
+        return new BenchmarkOptions(
+            Path.GetFullPath(pythonPath),
+            device,
+            Path.GetFullPath(videoPath),
+            frameCount,
+            Path.GetFullPath(benchmarkRoot),
+            workerCounts);
+    }
+}
+
+sealed record BenchmarkReport(
+    DateTimeOffset MeasuredAt,
+    NvidaSmiProbe? Probe,
+    BenchmarkEnvironment Environment,
+    IReadOnlyList<BenchmarkResult> Results);
+
+sealed record BenchmarkEnvironment(
+    string Device,
+    string PythonPath,
+    string WorkerScriptPath,
+    int FrameCount,
+    string VideoPath,
+    string BenchmarkRoot);
 
 sealed record BenchmarkResult(
-    string ModeName,
     int WorkerCount,
     int FrameCount,
     double WallClockMs,
@@ -176,4 +286,291 @@ sealed record BenchmarkResult(
     double AverageFrameMs,
     double MaxFrameMs,
     int SuccessCount,
-    int ErrorCount);
+    int ErrorCount,
+    NvidaSmiSummary? GpuSummary);
+
+sealed record FrameModeResult(
+    int FrameIndex,
+    long TimestampMs,
+    string Status,
+    double TotalMs,
+    double WorkerExecutionMs);
+
+sealed record NvidaSmiProbe(
+    string DriverVersion,
+    string CudaVersion,
+    IReadOnlyList<NvidaSmiGpuInfo> Gpus)
+{
+    public static async Task<NvidaSmiProbe?> TryCollectOnceAsync()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "nvidia-smi",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("--query-gpu=name,memory.total");
+        startInfo.ArgumentList.Add("--format=csv,noheader,nounits");
+
+        using var process = Process.Start(startInfo);
+        if (process is null)
+        {
+            return null;
+        }
+
+        var output = await process.StandardOutput.ReadToEndAsync();
+        await process.WaitForExitAsync();
+        if (process.ExitCode != 0)
+        {
+            return null;
+        }
+
+        var gpus = output
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(line =>
+            {
+                var parts = line.Split(',', StringSplitOptions.TrimEntries);
+                return new NvidaSmiGpuInfo(
+                    parts.ElementAtOrDefault(0) ?? string.Empty,
+                    BenchmarkParsing.ParseDouble(parts.ElementAtOrDefault(1)));
+            })
+            .ToArray();
+
+        var banner = await ReadNvidiaSmiBannerAsync();
+        return new NvidaSmiProbe(banner.DriverVersion, banner.CudaVersion, gpus);
+    }
+
+    private static async Task<(string DriverVersion, string CudaVersion)> ReadNvidiaSmiBannerAsync()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "nvidia-smi",
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(startInfo);
+        if (process is null)
+        {
+            return (string.Empty, string.Empty);
+        }
+
+        var output = await process.StandardOutput.ReadToEndAsync();
+        await process.WaitForExitAsync();
+        var line = output
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(text => text.Contains("Driver Version:", StringComparison.OrdinalIgnoreCase));
+        if (line is null)
+        {
+            return (string.Empty, string.Empty);
+        }
+
+        var driver = ExtractBannerValue(line, "Driver Version:");
+        var cuda = ExtractBannerValue(line, "CUDA Version:");
+        return (driver, cuda);
+    }
+
+    private static string ExtractBannerValue(string line, string label)
+    {
+        var index = line.IndexOf(label, StringComparison.OrdinalIgnoreCase);
+        if (index < 0)
+        {
+            return string.Empty;
+        }
+
+        var value = line[(index + label.Length)..];
+        var nextSeparator = value.IndexOf("  ", StringComparison.Ordinal);
+        if (nextSeparator >= 0)
+        {
+            value = value[..nextSeparator];
+        }
+
+        return value.Trim();
+    }
+}
+
+sealed record NvidaSmiGpuInfo(
+    string Name,
+    double? MemoryTotalMiB);
+
+sealed record NvidaSmiSample(
+    DateTimeOffset Timestamp,
+    double? UtilizationPercent,
+    double? MemoryUsedMiB,
+    double? MemoryTotalMiB);
+
+sealed record NvidaSmiSummary(
+    int SampleCount,
+    double? MaxUtilizationPercent,
+    double? AverageUtilizationPercent,
+    double? MaxMemoryUsedMiB,
+    double? AverageMemoryUsedMiB,
+    double? MemoryTotalMiB,
+    IReadOnlyList<NvidaSmiSample> Samples);
+
+sealed class NvidaSmiSampler : IAsyncDisposable
+{
+    private readonly TimeSpan _interval;
+    private readonly List<NvidaSmiSample> _samples = [];
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _task;
+
+    public NvidaSmiSampler(TimeSpan interval)
+    {
+        _interval = interval;
+    }
+
+    public static bool IsAvailable()
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "where.exe",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            startInfo.ArgumentList.Add("nvidia-smi");
+
+            using var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return false;
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit(5000);
+            return process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public Task StartAsync()
+    {
+        _task = Task.Run(SampleLoopAsync);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync()
+    {
+        _cts.Cancel();
+        if (_task is not null)
+        {
+            await _task;
+        }
+    }
+
+    public NvidaSmiSummary BuildSummary()
+    {
+        var utilizationValues = _samples
+            .Where(sample => sample.UtilizationPercent.HasValue)
+            .Select(sample => sample.UtilizationPercent!.Value)
+            .ToArray();
+        var memoryValues = _samples
+            .Where(sample => sample.MemoryUsedMiB.HasValue)
+            .Select(sample => sample.MemoryUsedMiB!.Value)
+            .ToArray();
+
+        return new NvidaSmiSummary(
+            _samples.Count,
+            utilizationValues.Length > 0 ? Math.Round(utilizationValues.Max(), 1) : null,
+            utilizationValues.Length > 0 ? Math.Round(utilizationValues.Average(), 1) : null,
+            memoryValues.Length > 0 ? Math.Round(memoryValues.Max(), 1) : null,
+            memoryValues.Length > 0 ? Math.Round(memoryValues.Average(), 1) : null,
+            _samples.LastOrDefault(sample => sample.MemoryTotalMiB.HasValue)?.MemoryTotalMiB,
+            _samples.ToArray());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync();
+        _cts.Dispose();
+    }
+
+    private async Task SampleLoopAsync()
+    {
+        while (!_cts.IsCancellationRequested)
+        {
+            try
+            {
+                var sample = await CollectSampleAsync();
+                if (sample is not null)
+                {
+                    _samples.Add(sample);
+                }
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                await Task.Delay(_interval, _cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    private static async Task<NvidaSmiSample?> CollectSampleAsync()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "nvidia-smi",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("--query-gpu=utilization.gpu,memory.used,memory.total");
+        startInfo.ArgumentList.Add("--format=csv,noheader,nounits");
+
+        using var process = Process.Start(startInfo);
+        if (process is null)
+        {
+            return null;
+        }
+
+        var output = await process.StandardOutput.ReadToEndAsync();
+        await process.WaitForExitAsync();
+        if (process.ExitCode != 0)
+        {
+            return null;
+        }
+
+        var firstLine = output
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault();
+        if (firstLine is null)
+        {
+            return null;
+        }
+
+        var parts = firstLine.Split(',', StringSplitOptions.TrimEntries);
+        return new NvidaSmiSample(
+            DateTimeOffset.Now,
+            BenchmarkParsing.ParseDouble(parts.ElementAtOrDefault(0)),
+            BenchmarkParsing.ParseDouble(parts.ElementAtOrDefault(1)),
+            BenchmarkParsing.ParseDouble(parts.ElementAtOrDefault(2)));
+    }
+}
+
+static class BenchmarkParsing
+{
+    public static double? ParseDouble(string? value)
+    {
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+}


### PR DESCRIPTION
## 概要
- `#158` の GPU 環境評価として OCR worker benchmark を GPU 向けに拡張
- RTX 2070 SUPER で `1 worker / 2 workers` の比較結果を `docs/test-results` に記録
- follow-up として `#164` を起票

## 変更内容
- `tools/validation/OcrWorkerModeBenchmark` に引数化と `nvidia-smi` サンプリングを追加
- GPU venv を使った benchmark 出力を JSON で取得可能にした
- `docs/test-results/2026-04-29_issue158_gpu_worker_evaluation.md` を追加

## 検証
- `dotnet build tools/validation/OcrWorkerModeBenchmark/OcrWorkerModeBenchmark.csproj -c Release -p:Platform=x64`
- `dotnet build src/MovieTelopTranscriber.sln -c Release -p:Platform=x64`
- `botirist.mp4` 40フレームで GPU 1/2 worker 比較
- `sample_basic_telop_60s.mp4` 60フレームで GPU 1/2 worker 比較