### PR TITLE
#168 設定画面サイズ再調整と GPU / ライセンス導線追加

### DIFF
--- a/docs/test-results/2026-04-29_issue168_settings_gpu_about_menu.md
+++ b/docs/test-results/2026-04-29_issue168_settings_gpu_about_menu.md
@@ -1,0 +1,23 @@
+# Issue #168 設定画面サイズ再調整と GPU / ライセンス / バージョン導線追加
+
+## 1. 変更概要
+- 設定画面の初期サイズを `1480 x 620` に再調整した。
+- 右ペインの最小幅を `720 -> 730` に拡大した。
+- 処理状況ペインの最小高さを `150 -> 160` に拡大した。
+- 設定画面に `PaddleOCR device` の選択 UI を追加し、`cpu` / `gpu:0` を選べるようにした。
+- `ヘルプ` メニューを追加し、`ライセンス` と `バージョン情報` のダイアログを開けるようにした。
+
+## 2. 検証
+| 項目 | コマンド / 操作 | 結果 |
+| --- | --- | --- |
+| Release build | `dotnet build .\\src\\MovieTelopTranscriber.sln -c Release -p:Platform=x64` | 成功。0 warnings / 0 errors |
+| diff 整合性 | `git diff --check` | エラーなし |
+| 起動確認 | Release build の `MovieTelopTranscriber.App.exe` を起動 | 成功。プロセスが 5 秒後も存続 |
+
+## 3. 起動確認対象
+- `D:\\Claude\\Movie\\movie-telop-transcriber\\src\\MovieTelopTranscriber.App\\bin\\x64\\Release\\net10.0-windows10.0.26100.0\\MovieTelopTranscriber.App.exe`
+
+## 4. 補足
+- `PaddleOCR device` を `gpu:0` にすると worker 数の選択 UI が有効化される。
+- `cpu` 選択時は worker 数を `1` に正規化する。
+- ライセンス画面は、同梱または設定対象の主要コンポーネント一覧と、OCR runtime のライセンス配置先の目安を表示する。

--- a/src/MovieTelopTranscriber.App/MainPage.xaml
+++ b/src/MovieTelopTranscriber.App/MainPage.xaml
@@ -37,6 +37,10 @@
                     <ToggleMenuFlyoutItem x:Name="TimelineConfidenceColumnMenuItem" Click="OnTimelineColumnVisibilityClicked" IsChecked="True" Tag="confidence" Text="{x:Bind ViewModel.UiText.TimelineColumnConfidence, Mode=OneWay}" />
                 </MenuFlyoutSubItem>
             </MenuBarItem>
+            <MenuBarItem Title="ヘルプ">
+                <MenuFlyoutItem Click="OnShowLicensesClicked" Text="ライセンス" />
+                <MenuFlyoutItem Click="OnShowVersionInfoClicked" Text="バージョン情報" />
+            </MenuBarItem>
         </MenuBar>
 
         <Border

--- a/src/MovieTelopTranscriber.App/MainPage.xaml.cs
+++ b/src/MovieTelopTranscriber.App/MainPage.xaml.cs
@@ -1,5 +1,7 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Reflection;
+using System.Text;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -22,7 +24,8 @@ namespace MovieTelopTranscriber.App;
 /// </summary>
 public sealed partial class MainPage : Page
 {
-    private const double MinimumRightPaneWidth = 720;
+    private const double MinimumRightPaneWidth = 730;
+    private const double MinimumActivityPaneHeight = 160;
 
     public static readonly DependencyProperty TimelineTimeColumnWidthProperty =
         DependencyProperty.Register(nameof(TimelineTimeColumnWidth), typeof(GridLength), typeof(MainPage), new PropertyMetadata(new GridLength(92)));
@@ -372,7 +375,7 @@ public sealed partial class MainPage : Page
         var currentY = e.GetCurrentPoint(this).Position.Y;
         var delta = currentY - _lastActivityPaneResizeY;
         _lastActivityPaneResizeY = currentY;
-        ActivityPaneHeight = ResizeGridLength(ActivityPaneHeight, -delta, 150);
+        ActivityPaneHeight = ResizeGridLength(ActivityPaneHeight, -delta, MinimumActivityPaneHeight);
         e.Handled = true;
     }
 
@@ -544,6 +547,78 @@ public sealed partial class MainPage : Page
         }
 
         UpdatePreviewPlaybackButtonContent();
+    }
+
+    private async void OnShowVersionInfoClicked(object sender, RoutedEventArgs e)
+    {
+        var assembly = typeof(App).Assembly;
+        var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? assembly.GetName().Version?.ToString()
+            ?? "0.0.0";
+        var settingsPath = App.LaunchSettingsPath ?? "(not found)";
+        var ocrDevice = Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_DEVICE") ?? "cpu";
+        var ocrEngine = Environment.GetEnvironmentVariable("MOVIE_TELOP_OCR_ENGINE") ?? "paddleocr";
+        var message = $"アプリバージョン: {version}\nビルド出力: {AppContext.BaseDirectory}\n設定ファイル: {settingsPath}\nOCR device: {ocrDevice}\nOCR エンジン: {ocrEngine}";
+
+        var dialog = new ContentDialog
+        {
+            XamlRoot = XamlRoot,
+            Title = "バージョン情報",
+            CloseButtonText = "閉じる",
+            DefaultButton = ContentDialogButton.Close,
+            Content = new TextBlock
+            {
+                Text = message,
+                TextWrapping = TextWrapping.WrapWholeWords,
+                Width = 720
+            }
+        };
+
+        await dialog.ShowAsync();
+    }
+
+    private async void OnShowLicensesClicked(object sender, RoutedEventArgs e)
+    {
+        var pythonPath = Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_PYTHON");
+        var licenseText = new StringBuilder()
+            .AppendLine("同梱または設定対象の主な構成:")
+            .AppendLine("- Microsoft Windows App SDK 1.8.260416003")
+            .AppendLine("- CommunityToolkit.Mvvm 8.4.2")
+            .AppendLine("- OpenCvSharp4.Windows 4.13.0.20260302")
+            .AppendLine("- PaddleOCR worker script (tools/ocr/paddle_ocr_worker.py)")
+            .AppendLine()
+            .AppendLine("OCR runtime の想定:")
+            .AppendLine("- CPU: PaddlePaddle 3.2.0 + PaddleOCR 3.5.0")
+            .AppendLine("- GPU: PaddlePaddle GPU 3.2.2 + PaddleOCR 3.5.0");
+
+        if (!string.IsNullOrWhiteSpace(pythonPath))
+        {
+            var sitePackages = System.IO.Path.GetFullPath(System.IO.Path.Combine(System.IO.Path.GetDirectoryName(pythonPath) ?? AppContext.BaseDirectory, "..", "Lib", "site-packages"));
+            licenseText
+                .AppendLine()
+                .AppendLine("詳細なライセンスファイル:")
+                .AppendLine(sitePackages);
+        }
+
+        var dialog = new ContentDialog
+        {
+            XamlRoot = XamlRoot,
+            Title = "ライセンス",
+            CloseButtonText = "閉じる",
+            DefaultButton = ContentDialogButton.Close,
+            Content = new ScrollViewer
+            {
+                Width = 760,
+                Height = 420,
+                Content = new TextBlock
+                {
+                    Text = licenseText.ToString(),
+                    TextWrapping = TextWrapping.WrapWholeWords
+                }
+            }
+        };
+
+        await dialog.ShowAsync();
     }
 
     private void OnPreviewPlaybackTimerTick(object? sender, object e)

--- a/src/MovieTelopTranscriber.App/Models/SelectionOption.cs
+++ b/src/MovieTelopTranscriber.App/Models/SelectionOption.cs
@@ -1,0 +1,3 @@
+namespace MovieTelopTranscriber.App.Models;
+
+public sealed record SelectionOption(string Key, string DisplayName);

--- a/src/MovieTelopTranscriber.App/SettingsWindow.xaml
+++ b/src/MovieTelopTranscriber.App/SettingsWindow.xaml
@@ -97,6 +97,19 @@
                             IsEnabled="{x:Bind ViewModel.CanInteract, Mode=OneWay}"
                             ToolTipService.ToolTip="{x:Bind ViewModel.UiText.PaddleSharpenDescription, Mode=OneWay}" />
                         <ComboBox
+                            Header="PaddleOCR device"
+                            HorizontalAlignment="Stretch"
+                            IsEnabled="{x:Bind ViewModel.CanInteract, Mode=OneWay}"
+                            ItemsSource="{x:Bind ViewModel.PaddleDeviceOptions, Mode=OneWay}"
+                            SelectedItem="{x:Bind ViewModel.SelectedPaddleDeviceOption, Mode=TwoWay}"
+                            ToolTipService.ToolTip="cpu または gpu:0 を選びます。GPU を使うには、この PC に GPU 対応の Paddle runtime が入っている必要があります。">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate x:DataType="models:SelectionOption">
+                                    <TextBlock Text="{x:Bind DisplayName}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                        <ComboBox
                             Header="{x:Bind ViewModel.UiText.PaddleWorkerCountLabel, Mode=OneWay}"
                             HorizontalAlignment="Stretch"
                             IsEnabled="{x:Bind ViewModel.IsPaddleWorkerCountEditable, Mode=OneWay}"

--- a/src/MovieTelopTranscriber.App/SettingsWindow.xaml.cs
+++ b/src/MovieTelopTranscriber.App/SettingsWindow.xaml.cs
@@ -14,7 +14,7 @@ public sealed partial class SettingsWindow : Window
 
         Title = "Settings - Movie Telop Transcriber";
         AppWindow.SetIcon("Assets/AppIcon.ico");
-        AppWindow.Resize(new SizeInt32(1120, 480));
+        AppWindow.Resize(new SizeInt32(1480, 620));
         if (AppWindow.Presenter is OverlappedPresenter presenter)
         {
             presenter.IsResizable = false;

--- a/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
+++ b/src/MovieTelopTranscriber.App/ViewModels/MainPageViewModel.cs
@@ -46,6 +46,7 @@ public partial class MainPageViewModel : ObservableObject
     private const string PaddleMinTextSizeEnvironmentVariable = "MOVIE_TELOP_PADDLEOCR_MIN_TEXT_SIZE";
     private const string PaddleUseTextlineOrientationEnvironmentVariable = "MOVIE_TELOP_PADDLEOCR_USE_TEXTLINE_ORIENTATION";
     private const string PaddleUseDocUnwarpingEnvironmentVariable = "MOVIE_TELOP_PADDLEOCR_USE_DOC_UNWARPING";
+    private const string PaddleDeviceEnvironmentVariable = "MOVIE_TELOP_PADDLEOCR_DEVICE";
     private const string PaddleWorkerCountEnvironmentVariable = "MOVIE_TELOP_PADDLEOCR_WORKER_COUNT";
 
     private readonly OpenCvVideoProcessingService _videoProcessingService = new();
@@ -60,6 +61,12 @@ public partial class MainPageViewModel : ObservableObject
         new("en", "English"),
         new("zh", "中文"),
         new("ko", "한국어")
+    ];
+
+    private static readonly SelectionOption[] SupportedPaddleDeviceOptions =
+    [
+        new("cpu", "CPU"),
+        new("gpu:0", "GPU (gpu:0)")
     ];
 
     private IReadOnlyList<FrameAnalysisResult> _latestFrameAnalyses = Array.Empty<FrameAnalysisResult>();
@@ -93,6 +100,7 @@ public partial class MainPageViewModel : ObservableObject
         SelectedLanguageOption = ResolveDefaultLanguageOption();
         ApplySavedUserInterfaceSettings();
         UiText = LocalizedUiText.ForLanguage(SelectedLanguageOption.Code);
+        SelectedPaddleDeviceOption = ResolvePaddleDeviceOption(Environment.GetEnvironmentVariable(PaddleDeviceEnvironmentVariable));
         ApplyPaddleOcrEnvironment();
         RefreshStaticCollections();
         ResetDynamicCollections();
@@ -112,6 +120,8 @@ public partial class MainPageViewModel : ObservableObject
     public ObservableCollection<PreviewDetectionOverlay> PreviewDetections { get; }
 
     public IReadOnlyList<int> PaddleWorkerCountOptions { get; } = [1, 2];
+
+    public IReadOnlyList<SelectionOption> PaddleDeviceOptions { get; } = SupportedPaddleDeviceOptions;
 
     public event EventHandler? SettingsWindowRequested;
 
@@ -171,7 +181,7 @@ public partial class MainPageViewModel : ObservableObject
 
     public bool CanInteract => !IsBusy;
 
-    public bool IsPaddleWorkerCountEditable => CanInteract && IsGpuDevice(Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_DEVICE"));
+    public bool IsPaddleWorkerCountEditable => CanInteract && IsGpuDevice(SelectedPaddleDeviceOption.Key);
 
     [ObservableProperty]
     public partial string FrameIntervalText { get; set; } = "1.0";
@@ -229,6 +239,9 @@ public partial class MainPageViewModel : ObservableObject
 
     [ObservableProperty]
     public partial bool PaddleUseDocUnwarping { get; set; } = ReadBoolEnvironment(PaddleUseDocUnwarpingEnvironmentVariable, false);
+
+    [ObservableProperty]
+    public partial SelectionOption SelectedPaddleDeviceOption { get; set; } = SupportedPaddleDeviceOptions[0];
 
     [ObservableProperty]
     public partial int PaddleWorkerCount { get; set; } = ReadPaddleWorkerCountSetting();
@@ -465,9 +478,17 @@ public partial class MainPageViewModel : ObservableObject
         OnUserSettingsChanged();
     }
 
+    partial void OnSelectedPaddleDeviceOptionChanged(SelectionOption value)
+    {
+        PaddleWorkerCount = NormalizePaddleWorkerCount(PaddleWorkerCount, value.Key);
+        OnPropertyChanged(nameof(IsPaddleWorkerCountEditable));
+        RefreshStaticCollections();
+        OnUserSettingsChanged();
+    }
+
     partial void OnPaddleWorkerCountChanged(int value)
     {
-        var normalized = NormalizePaddleWorkerCount(value);
+        var normalized = NormalizePaddleWorkerCount(value, SelectedPaddleDeviceOption.Key);
         if (normalized != value)
         {
             PaddleWorkerCount = normalized;
@@ -2972,7 +2993,7 @@ public partial class MainPageViewModel : ObservableObject
         App.LaunchSettings.PaddleOcr ??= new PaddleOcrLaunchSettings();
         App.LaunchSettings.PaddleOcr.PythonPath = Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_PYTHON");
         App.LaunchSettings.PaddleOcr.ScriptPath = Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_SCRIPT");
-        App.LaunchSettings.PaddleOcr.Device = Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_DEVICE");
+        App.LaunchSettings.PaddleOcr.Device = SelectedPaddleDeviceOption.Key;
         App.LaunchSettings.PaddleOcr.Language = Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_LANG");
         App.LaunchSettings.PaddleOcr.MinScore = ReadEnvironmentDouble("MOVIE_TELOP_PADDLEOCR_MIN_SCORE");
         App.LaunchSettings.PaddleOcr.NormalizeSmallKana = ReadEnvironmentBool("MOVIE_TELOP_PADDLEOCR_NORMALIZE_SMALL_KANA");
@@ -2986,7 +3007,7 @@ public partial class MainPageViewModel : ObservableObject
         App.LaunchSettings.PaddleOcr.MinTextSize = ParseOptionalDouble(PaddleMinTextSizeText, 0.0d, 200.0d);
         App.LaunchSettings.PaddleOcr.UseTextlineOrientation = PaddleUseTextlineOrientation;
         App.LaunchSettings.PaddleOcr.UseDocUnwarping = PaddleUseDocUnwarping;
-        App.LaunchSettings.PaddleOcr.WorkerCount = NormalizePaddleWorkerCount(PaddleWorkerCount);
+        App.LaunchSettings.PaddleOcr.WorkerCount = NormalizePaddleWorkerCount(PaddleWorkerCount, SelectedPaddleDeviceOption.Key);
 
         App.LaunchSettings.Ui ??= new UserInterfaceSettings();
         App.LaunchSettings.Ui.Language = SelectedLanguageOption.Code;
@@ -3005,6 +3026,7 @@ public partial class MainPageViewModel : ObservableObject
 
     private void ApplyPaddleOcrEnvironment()
     {
+        SetEnvironment(PaddleDeviceEnvironmentVariable, SelectedPaddleDeviceOption.Key);
         SetEnvironment(PaddlePreprocessEnvironmentVariable, PaddlePreprocessEnabled ? "true" : "false");
         SetEnvironment(PaddleUpscaleEnvironmentVariable, FixedPaddleUpscale);
         SetDoubleEnvironment(PaddleContrastEnvironmentVariable, PaddleContrastText, 0.1d, 4.0d);
@@ -3016,7 +3038,7 @@ public partial class MainPageViewModel : ObservableObject
         SetDoubleEnvironment(PaddleMinTextSizeEnvironmentVariable, PaddleMinTextSizeText, 0.0d, 200.0d);
         SetEnvironment(PaddleUseTextlineOrientationEnvironmentVariable, PaddleUseTextlineOrientation ? "true" : "false");
         SetEnvironment(PaddleUseDocUnwarpingEnvironmentVariable, PaddleUseDocUnwarping ? "true" : "false");
-        SetEnvironment(PaddleWorkerCountEnvironmentVariable, NormalizePaddleWorkerCount(PaddleWorkerCount).ToString(CultureInfo.InvariantCulture));
+        SetEnvironment(PaddleWorkerCountEnvironmentVariable, NormalizePaddleWorkerCount(PaddleWorkerCount, SelectedPaddleDeviceOption.Key).ToString(CultureInfo.InvariantCulture));
     }
 
     private static RunPerformanceSummaryRecord BuildPerformanceSummary(
@@ -3071,12 +3093,12 @@ public partial class MainPageViewModel : ObservableObject
 
     private string FormatPaddleDetectionSummary()
     {
-        var workerSummary = IsGpuDevice(Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_DEVICE"))
-            ? $"{NormalizePaddleWorkerCount(PaddleWorkerCount)} workers"
+        var workerSummary = IsGpuDevice(SelectedPaddleDeviceOption.Key)
+            ? $"{NormalizePaddleWorkerCount(PaddleWorkerCount, SelectedPaddleDeviceOption.Key)} workers"
             : "CPU fixed to 1 worker";
         var orientation = PaddleUseTextlineOrientation ? "orientation ON" : "orientation OFF";
         var unwarping = PaddleUseDocUnwarping ? "unwarp ON" : "unwarp OFF";
-        return $"det {FormatSettingValue(PaddleTextDetThreshText)} / box {FormatSettingValue(PaddleTextDetBoxThreshText)} / unclip {FormatSettingValue(PaddleTextDetUnclipRatioText)} / limit {FormatSettingValue(PaddleTextDetLimitSideLenText)} / min size {FormatSettingValue(PaddleMinTextSizeText)} / {workerSummary} / {orientation} / {unwarping}";
+        return $"device {SelectedPaddleDeviceOption.Key} / det {FormatSettingValue(PaddleTextDetThreshText)} / box {FormatSettingValue(PaddleTextDetBoxThreshText)} / unclip {FormatSettingValue(PaddleTextDetUnclipRatioText)} / limit {FormatSettingValue(PaddleTextDetLimitSideLenText)} / min size {FormatSettingValue(PaddleMinTextSizeText)} / {workerSummary} / {orientation} / {unwarping}";
     }
 
     private string FormatSettingValue(string value)
@@ -3174,8 +3196,9 @@ public partial class MainPageViewModel : ObservableObject
     private static int ReadPaddleWorkerCountSetting()
     {
         var value = Environment.GetEnvironmentVariable(PaddleWorkerCountEnvironmentVariable);
+        var device = Environment.GetEnvironmentVariable(PaddleDeviceEnvironmentVariable);
         return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
-            ? NormalizePaddleWorkerCount(parsed)
+            ? NormalizePaddleWorkerCount(parsed, device)
             : 1;
     }
 
@@ -3205,18 +3228,22 @@ public partial class MainPageViewModel : ObservableObject
             && device.Trim().StartsWith("gpu", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static int NormalizePaddleWorkerCount(int value)
+    private static SelectionOption ResolvePaddleDeviceOption(string? device)
+    {
+        var normalizedKey = IsGpuDevice(device) ? "gpu:0" : "cpu";
+        return SupportedPaddleDeviceOptions.First(option => option.Key == normalizedKey);
+    }
+
+    private static int NormalizePaddleWorkerCount(int value, string? device)
     {
         var normalized = Math.Clamp(value, 1, 2);
-        return IsGpuDevice(Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_DEVICE"))
-            ? normalized
-            : 1;
+        return IsGpuDevice(device) ? normalized : 1;
     }
 
     private int ResolveEffectivePaddleWorkerCount(string ocrEngine)
     {
         return string.Equals(ocrEngine, "paddleocr", StringComparison.OrdinalIgnoreCase)
-            ? NormalizePaddleWorkerCount(PaddleWorkerCount)
+            ? NormalizePaddleWorkerCount(PaddleWorkerCount, SelectedPaddleDeviceOption.Key)
             : 1;
     }
 


### PR DESCRIPTION
﻿## 概要
- 設定画面の初期サイズをリリース基準で再調整
- 右ペインと処理状況ペインの最小サイズを微調整
- 設定画面に PaddleOCR device 選択を追加
- ヘルプメニューからライセンス / バージョン情報を開けるように変更

## 検証
- dotnet build .\src\MovieTelopTranscriber.sln -c Release -p:Platform=x64
- git diff --check
- Release build の App.exe 起動確認
