### PR TITLE
#171 設定画面の高さを 1.5 倍へ再調整

### DIFF
--- a/docs/test-results/2026-04-30_issue171_settings_window_height.md
+++ b/docs/test-results/2026-04-30_issue171_settings_window_height.md
@@ -1,0 +1,14 @@
+# Issue #171 設定画面の高さ再調整
+
+## 1. 変更概要
+- 設定画面の初期サイズを `1480 x 620` から `1480 x 930` に変更した。
+
+## 2. 検証
+| 項目 | コマンド / 操作 | 結果 |
+| --- | --- | --- |
+| Release build | `dotnet build .\\src\\MovieTelopTranscriber.sln -c Release -p:Platform=x64` | 成功。0 warnings / 0 errors |
+| diff 整合性 | `git diff --check` | エラーなし |
+| 起動確認 | Release build の `MovieTelopTranscriber.App.exe` を起動 | 成功。プロセスが 5 秒後も存続 |
+
+## 3. 起動確認対象
+- `D:\\Claude\\Movie\\movie-telop-transcriber\\src\\MovieTelopTranscriber.App\\bin\\x64\\Release\\net10.0-windows10.0.26100.0\\MovieTelopTranscriber.App.exe`

--- a/src/MovieTelopTranscriber.App/SettingsWindow.xaml.cs
+++ b/src/MovieTelopTranscriber.App/SettingsWindow.xaml.cs
@@ -14,7 +14,7 @@ public sealed partial class SettingsWindow : Window
 
         Title = "Settings - Movie Telop Transcriber";
         AppWindow.SetIcon("Assets/AppIcon.ico");
-        AppWindow.Resize(new SizeInt32(1480, 620));
+        AppWindow.Resize(new SizeInt32(1480, 930));
         if (AppWindow.Presenter is OverlappedPresenter presenter)
         {
             presenter.IsResizable = false;


### PR DESCRIPTION
﻿## 概要
- 設定画面の高さを 620 から 930 に拡大
- 横幅 1480 は維持し、最新リリース基準で縦方向の窮屈さを緩和
- 検証結果を docs/test-results に追加

## 検証
- dotnet build .\src\MovieTelopTranscriber.sln -c Release -p:Platform=x64
- git diff --check
- Release build の EXE 起動確認
