### PR TITLE
#174 プレビュー別画面化とレイアウト追加調整を反映する

### DIFF
--- a/docs/test-results/2026-04-30_issue174_preview_popup_layout.md
+++ b/docs/test-results/2026-04-30_issue174_preview_popup_layout.md
@@ -1,0 +1,19 @@
+﻿# 2026-04-30 Issue 174 Preview Popup And Layout Adjustment
+
+## 実施内容
+- 設定画面の初期高さを `950px` へ拡張
+- メイン画面右ペインの最低幅を `750px` へ拡張し、右ペイン host の `MinWidth` を `740px` に更新
+- 初回起動時のメイン画面幅を `1800px` に変更
+- プレビューを別画面へ表示するアイコンボタンを再生ボタン横へ追加
+- プレビュー別画面を閉じるとメイン画面側へプレビュー表示が戻るようにした
+- プレビュー別画面表示中は中央ペイン幅を `380px` に固定して、最小幅寄りのレイアウトへ切り替えるようにした
+- 既存のヘルプ / ライセンス周辺に残っていた文字化け文字列を正常化した
+
+## 実装メモ
+- `PreviewFrameView` をコード構築の共通コントロールとして追加し、メイン画面とポップアップ画面で同じ描画ロジックを共有
+- `PreviewWindow` を追加し、同一 `MainPageViewModel` のプレビュー状態を別ウィンドウで表示
+
+## 検証
+- `dotnet build .\\src\\MovieTelopTranscriber.sln -c Release -p:Platform=x64`
+- `git diff --check`
+- Release build の EXE 起動確認

--- a/src/MovieTelopTranscriber.App/Controls/PreviewFrameView.xaml.cs
+++ b/src/MovieTelopTranscriber.App/Controls/PreviewFrameView.xaml.cs
@@ -1,0 +1,322 @@
+using System.Collections;
+using System.Collections.Specialized;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Xaml.Shapes;
+using MovieTelopTranscriber.App.Models;
+using Windows.Foundation;
+
+namespace MovieTelopTranscriber.App.Controls;
+
+public sealed class PreviewFrameView : UserControl
+{
+    public static readonly DependencyProperty ImagePathProperty =
+        DependencyProperty.Register(nameof(ImagePath), typeof(string), typeof(PreviewFrameView), new PropertyMetadata(null, OnPreviewPropertyChanged));
+
+    public static readonly DependencyProperty SourceWidthProperty =
+        DependencyProperty.Register(nameof(SourceWidth), typeof(int), typeof(PreviewFrameView), new PropertyMetadata(0, OnPreviewPropertyChanged));
+
+    public static readonly DependencyProperty SourceHeightProperty =
+        DependencyProperty.Register(nameof(SourceHeight), typeof(int), typeof(PreviewFrameView), new PropertyMetadata(0, OnPreviewPropertyChanged));
+
+    public static readonly DependencyProperty DetectionsProperty =
+        DependencyProperty.Register(nameof(Detections), typeof(IEnumerable), typeof(PreviewFrameView), new PropertyMetadata(null, OnDetectionsChanged));
+
+    public static readonly DependencyProperty EmptyStateTextProperty =
+        DependencyProperty.Register(nameof(EmptyStateText), typeof(string), typeof(PreviewFrameView), new PropertyMetadata(string.Empty, OnPreviewPropertyChanged));
+
+    public static readonly DependencyProperty EmptyCaptionTextProperty =
+        DependencyProperty.Register(nameof(EmptyCaptionText), typeof(string), typeof(PreviewFrameView), new PropertyMetadata(string.Empty, OnPreviewPropertyChanged));
+
+    public static readonly DependencyProperty FrameMinHeightProperty =
+        DependencyProperty.Register(nameof(FrameMinHeight), typeof(double), typeof(PreviewFrameView), new PropertyMetadata(280d, OnPreviewPropertyChanged));
+
+    private readonly Border _frameContainer;
+    private readonly Image _frameImage;
+    private readonly Canvas _overlayCanvas;
+    private readonly StackPanel _emptyStatePanel;
+    private readonly TextBlock _emptyStateTextBlock;
+    private readonly TextBlock _emptyCaptionTextBlock;
+    private INotifyCollectionChanged? _observedDetections;
+
+    public PreviewFrameView()
+    {
+        _frameImage = new Image
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Stretch = Stretch.Uniform
+        };
+        _frameImage.ImageOpened += OnFrameImageOpened;
+        _frameImage.ImageFailed += OnFrameImageFailed;
+
+        _overlayCanvas = new Canvas
+        {
+            IsHitTestVisible = false
+        };
+
+        _emptyStateTextBlock = new TextBlock
+        {
+            HorizontalAlignment = HorizontalAlignment.Center,
+            TextAlignment = TextAlignment.Center
+        };
+
+        _emptyCaptionTextBlock = new TextBlock
+        {
+            HorizontalAlignment = HorizontalAlignment.Center,
+            TextAlignment = TextAlignment.Center,
+            TextWrapping = TextWrapping.WrapWholeWords
+        };
+
+        _emptyStatePanel = new StackPanel
+        {
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 8
+        };
+        _emptyStatePanel.Children.Add(new FontIcon
+        {
+            Glyph = "\uE714",
+            FontSize = 32
+        });
+        _emptyStatePanel.Children.Add(_emptyStateTextBlock);
+        _emptyStatePanel.Children.Add(_emptyCaptionTextBlock);
+
+        var layoutGrid = new Grid();
+        layoutGrid.Children.Add(_frameImage);
+        layoutGrid.Children.Add(_overlayCanvas);
+        layoutGrid.Children.Add(_emptyStatePanel);
+
+        _frameContainer = new Border
+        {
+            Background = Application.Current.Resources["LayerOnAcrylicFillColorDefaultBrush"] as Brush,
+            CornerRadius = new CornerRadius(6),
+            Child = layoutGrid
+        };
+        _frameContainer.SizeChanged += OnFrameContainerSizeChanged;
+
+        Content = _frameContainer;
+        UpdatePreviewImage();
+    }
+
+    public string? ImagePath
+    {
+        get => (string?)GetValue(ImagePathProperty);
+        set => SetValue(ImagePathProperty, value);
+    }
+
+    public int SourceWidth
+    {
+        get => (int)GetValue(SourceWidthProperty);
+        set => SetValue(SourceWidthProperty, value);
+    }
+
+    public int SourceHeight
+    {
+        get => (int)GetValue(SourceHeightProperty);
+        set => SetValue(SourceHeightProperty, value);
+    }
+
+    public IEnumerable? Detections
+    {
+        get => (IEnumerable?)GetValue(DetectionsProperty);
+        set => SetValue(DetectionsProperty, value);
+    }
+
+    public string EmptyStateText
+    {
+        get => (string)GetValue(EmptyStateTextProperty);
+        set => SetValue(EmptyStateTextProperty, value);
+    }
+
+    public string EmptyCaptionText
+    {
+        get => (string)GetValue(EmptyCaptionTextProperty);
+        set => SetValue(EmptyCaptionTextProperty, value);
+    }
+
+    public double FrameMinHeight
+    {
+        get => (double)GetValue(FrameMinHeightProperty);
+        set => SetValue(FrameMinHeightProperty, value);
+    }
+
+    private static void OnPreviewPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is PreviewFrameView view)
+        {
+            view.UpdatePreviewImage();
+        }
+    }
+
+    private static void OnDetectionsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not PreviewFrameView view)
+        {
+            return;
+        }
+
+        if (view._observedDetections is not null)
+        {
+            view._observedDetections.CollectionChanged -= view.OnDetectionsCollectionChanged;
+        }
+
+        view._observedDetections = e.NewValue as INotifyCollectionChanged;
+        if (view._observedDetections is not null)
+        {
+            view._observedDetections.CollectionChanged += view.OnDetectionsCollectionChanged;
+        }
+
+        view.RedrawOverlay();
+    }
+
+    private void OnDetectionsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        RedrawOverlay();
+    }
+
+    private void OnFrameContainerSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        RedrawOverlay();
+    }
+
+    private void OnFrameImageOpened(object sender, RoutedEventArgs e)
+    {
+        RedrawOverlay();
+    }
+
+    private void OnFrameImageFailed(object sender, ExceptionRoutedEventArgs e)
+    {
+        _overlayCanvas.Children.Clear();
+        _frameImage.Source = null;
+        UpdatePreviewVisibility(hasImage: false);
+    }
+
+    private void UpdatePreviewImage()
+    {
+        _frameContainer.MinHeight = FrameMinHeight;
+        _emptyStateTextBlock.Text = EmptyStateText;
+        _emptyCaptionTextBlock.Text = EmptyCaptionText;
+
+        if (string.IsNullOrWhiteSpace(ImagePath) || !File.Exists(ImagePath))
+        {
+            _frameImage.Source = null;
+            _overlayCanvas.Children.Clear();
+            UpdatePreviewVisibility(hasImage: false);
+            return;
+        }
+
+        _frameImage.Source = new BitmapImage(new Uri(System.IO.Path.GetFullPath(ImagePath), UriKind.Absolute));
+        UpdatePreviewVisibility(hasImage: true);
+        RedrawOverlay();
+    }
+
+    private void UpdatePreviewVisibility(bool hasImage)
+    {
+        _frameImage.Visibility = hasImage ? Visibility.Visible : Visibility.Collapsed;
+        _overlayCanvas.Visibility = hasImage ? Visibility.Visible : Visibility.Collapsed;
+        _emptyStatePanel.Visibility = hasImage ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    private void RedrawOverlay()
+    {
+        _overlayCanvas.Children.Clear();
+
+        if (SourceWidth <= 0 || SourceHeight <= 0)
+        {
+            return;
+        }
+
+        var detections = Detections?.OfType<PreviewDetectionOverlay>().ToList() ?? [];
+        if (detections.Count == 0)
+        {
+            return;
+        }
+
+        var containerWidth = _frameContainer.ActualWidth;
+        var containerHeight = _frameContainer.ActualHeight;
+        if (containerWidth <= 0 || containerHeight <= 0)
+        {
+            return;
+        }
+
+        _overlayCanvas.Width = containerWidth;
+        _overlayCanvas.Height = containerHeight;
+
+        var scale = Math.Min(containerWidth / SourceWidth, containerHeight / SourceHeight);
+        var displayWidth = SourceWidth * scale;
+        var displayHeight = SourceHeight * scale;
+        var offsetX = (containerWidth - displayWidth) / 2d;
+        var offsetY = (containerHeight - displayHeight) / 2d;
+
+        foreach (var detection in detections)
+        {
+            DrawDetectionOverlay(detection, scale, offsetX, offsetY);
+        }
+    }
+
+    private void DrawDetectionOverlay(
+        PreviewDetectionOverlay detection,
+        double scale,
+        double offsetX,
+        double offsetY)
+    {
+        if (detection.BoundingBox.Count == 0)
+        {
+            return;
+        }
+
+        var strokeBrush = detection.IsHighlighted
+            ? new SolidColorBrush(Colors.OrangeRed)
+            : new SolidColorBrush(Colors.DeepSkyBlue);
+        var fillBrush = detection.IsHighlighted
+            ? new SolidColorBrush(ColorHelper.FromArgb(36, 255, 69, 0))
+            : new SolidColorBrush(ColorHelper.FromArgb(24, 0, 191, 255));
+
+        var polygon = new Polygon
+        {
+            Stroke = strokeBrush,
+            StrokeThickness = detection.IsHighlighted ? 3 : 2,
+            Fill = fillBrush,
+            Points = new PointCollection()
+        };
+
+        foreach (var point in detection.BoundingBox)
+        {
+            polygon.Points.Add(new Point(offsetX + (point.X * scale), offsetY + (point.Y * scale)));
+        }
+
+        _overlayCanvas.Children.Add(polygon);
+
+        var minX = detection.BoundingBox.Min(point => point.X);
+        var minY = detection.BoundingBox.Min(point => point.Y);
+        var label = new Border
+        {
+            Background = new SolidColorBrush(ColorHelper.FromArgb(224, 16, 16, 16)),
+            CornerRadius = new CornerRadius(4),
+            Padding = new Thickness(6, 2, 6, 3),
+            Child = new TextBlock
+            {
+                Foreground = new SolidColorBrush(Colors.White),
+                FontSize = 11,
+                Text = CreateDetectionLabel(detection),
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                MaxWidth = 220
+            }
+        };
+
+        Canvas.SetLeft(label, offsetX + (minX * scale));
+        Canvas.SetTop(label, Math.Max(0, offsetY + (minY * scale) - 24));
+        _overlayCanvas.Children.Add(label);
+    }
+
+    private static string CreateDetectionLabel(PreviewDetectionOverlay detection)
+    {
+        return detection.Confidence is null
+            ? detection.Text
+            : $"{detection.Text} ({detection.Confidence:P0})";
+    }
+}

--- a/src/MovieTelopTranscriber.App/MainPage.xaml
+++ b/src/MovieTelopTranscriber.App/MainPage.xaml
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <Page
     x:Class="MovieTelopTranscriber.App.MainPage"
     x:Name="RootPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:MovieTelopTranscriber.App.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:models="using:MovieTelopTranscriber.App.Models"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -69,7 +70,7 @@
         <Grid Grid.Row="2" ColumnSpacing="12">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="340" />
-                <ColumnDefinition Width="*" />
+                <ColumnDefinition x:Name="CenterPaneColumn" Width="*" />
                 <ColumnDefinition Width="8" />
                 <ColumnDefinition Width="{Binding RightPaneWidth, ElementName=RootPage}" />
             </Grid.ColumnDefinitions>
@@ -199,6 +200,7 @@
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="{x:Bind ViewModel.UiText.PreviewSection, Mode=OneWay}" Style="{StaticResource AppSectionTitleTextStyle}" />
                             <ToggleButton
@@ -210,44 +212,53 @@
                                 Grid.Column="2"
                                 Click="OnPreviewPlaybackClicked"
                                 Content="{x:Bind ViewModel.UiText.PreviewPlay, Mode=OneWay}" />
+                            <Button
+                                x:Name="PreviewPopOutButton"
+                                Grid.Column="3"
+                                Click="OnPreviewPopOutClicked" />
                         </Grid>
 
-                        <Border
+                        <Grid
                             Grid.Row="1"
-                            x:Name="PreviewFrameContainer"
-                            MinHeight="280"
-                            Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
-                            CornerRadius="6"
-                            SizeChanged="OnPreviewFrameContainerSizeChanged">
-                            <Grid>
-                                <Image
-                                    x:Name="PreviewFrameImage"
-                                    HorizontalAlignment="Stretch"
-                                    VerticalAlignment="Stretch"
-                                    ImageFailed="OnPreviewFrameImageFailed"
-                                    ImageOpened="OnPreviewFrameImageOpened"
-                                    Stretch="Uniform" />
-                                <Canvas
-                                    x:Name="PreviewOverlayCanvas"
-                                    IsHitTestVisible="False" />
-                                <StackPanel
-                                    x:Name="PreviewEmptyState"
+                            MinHeight="280">
+                            <controls:PreviewFrameView
+                                x:Name="EmbeddedPreviewFrameView"
+                                EmptyCaptionText="{x:Bind ViewModel.UiText.PreviewShell, Mode=OneWay}"
+                                EmptyStateText="{x:Bind ViewModel.PreviewState, Mode=OneWay}"
+                                FrameMinHeight="280"
+                                ImagePath="{x:Bind ViewModel.PreviewImagePath, Mode=OneWay}"
+                                SourceHeight="{x:Bind ViewModel.PreviewImageHeight, Mode=OneWay}"
+                                SourceWidth="{x:Bind ViewModel.PreviewImageWidth, Mode=OneWay}"
+                                Detections="{x:Bind ViewModel.PreviewDetections, Mode=OneWay}" />
+                            <StackPanel
+                                x:Name="PreviewDetachedStatePanel"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Spacing="8"
+                                Visibility="Collapsed">
+                                <FontIcon Glyph="&#xE8A7;" FontSize="32" />
+                                <TextBlock
                                     HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Spacing="8">
-                                    <FontIcon Glyph="&#xE714;" FontSize="32" />
-                                    <TextBlock
-                                        HorizontalAlignment="Center"
-                                        Text="{x:Bind ViewModel.PreviewState, Mode=OneWay}"
-                                        TextAlignment="Center" />
+                                    Text="プレビューを別画面で表示中です。"
+                                    TextAlignment="Center" />
+                                <StackPanel
+                                    HorizontalAlignment="Center"
+                                    Spacing="4">
                                     <TextBlock
                                         HorizontalAlignment="Center"
                                         Style="{StaticResource AppSecondaryTextStyle}"
-                                        Text="{x:Bind ViewModel.UiText.PreviewShell, Mode=OneWay}"
-                                        TextAlignment="Center" />
+                                        Text="{x:Bind ViewModel.SelectedSegmentSummary, Mode=OneWay}"
+                                        TextAlignment="Center"
+                                        TextWrapping="WrapWholeWords" />
+                                    <TextBlock
+                                        HorizontalAlignment="Center"
+                                        Style="{StaticResource AppSecondaryTextStyle}"
+                                        Text="{x:Bind ViewModel.PreviewDetailText, Mode=OneWay}"
+                                        TextAlignment="Center"
+                                        TextWrapping="WrapWholeWords" />
                                 </StackPanel>
-                            </Grid>
-                        </Border>
+                            </StackPanel>
+                        </Grid>
 
                         <StackPanel Grid.Row="2" Spacing="6">
                             <Grid ColumnSpacing="10">
@@ -345,7 +356,7 @@
             <Border
                 x:Name="RightPaneHost"
                 Grid.Column="3"
-                MinWidth="720"
+                MinWidth="740"
                 Padding="16"
                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"

--- a/src/MovieTelopTranscriber.App/MainPage.xaml.cs
+++ b/src/MovieTelopTranscriber.App/MainPage.xaml.cs
@@ -1,4 +1,4 @@
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Reflection;
 using System.Text;
@@ -7,11 +7,8 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Media.Imaging;
-using Microsoft.UI.Xaml.Shapes;
 using MovieTelopTranscriber.App.Models;
 using MovieTelopTranscriber.App.ViewModels;
-using Windows.Foundation;
 using Windows.System;
 
 // To learn more about WinUI, the WinUI project structure,
@@ -24,8 +21,9 @@ namespace MovieTelopTranscriber.App;
 /// </summary>
 public sealed partial class MainPage : Page
 {
-    private const double MinimumRightPaneWidth = 730;
+    private const double MinimumRightPaneWidth = 750;
     private const double MinimumActivityPaneHeight = 160;
+    private const double DetachedCenterPaneWidth = 380;
 
     public static readonly DependencyProperty TimelineTimeColumnWidthProperty =
         DependencyProperty.Register(nameof(TimelineTimeColumnWidth), typeof(GridLength), typeof(MainPage), new PropertyMetadata(new GridLength(92)));
@@ -85,6 +83,7 @@ public sealed partial class MainPage : Page
         DependencyProperty.Register(nameof(ActivityPaneHeight), typeof(GridLength), typeof(MainPage), new PropertyMetadata(new GridLength(160)));
 
     private SettingsWindow? _settingsWindow;
+    private PreviewWindow? _previewWindow;
     private string? _activeTimelineColumnResize;
     private double _lastTimelineResizeX;
     private bool _isResizingRightPane;
@@ -221,10 +220,10 @@ public sealed partial class MainPage : Page
         InitializeComponent();
         ViewModel.SettingsWindowRequested += OnSettingsWindowRequested;
         ViewModel.PropertyChanged += OnViewModelPropertyChanged;
-        ViewModel.PreviewDetections.CollectionChanged += OnPreviewDetectionsChanged;
         _previewPlaybackTimer.Tick += OnPreviewPlaybackTimerTick;
         RefreshTimelineColumnWidths();
-        UpdatePreviewImage();
+        UpdatePreviewPlaybackButtonContent();
+        UpdatePreviewPopOutButtonState();
     }
 
     private void OnSettingsWindowRequested(object? sender, EventArgs e)
@@ -240,45 +239,11 @@ public sealed partial class MainPage : Page
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(MainPageViewModel.PreviewImagePath))
-        {
-            UpdatePreviewImage();
-            return;
-        }
-
-        if (e.PropertyName is nameof(MainPageViewModel.PreviewImageWidth)
-            or nameof(MainPageViewModel.PreviewImageHeight))
-        {
-            RedrawPreviewOverlay();
-            return;
-        }
-
         if (e.PropertyName is nameof(MainPageViewModel.UiText))
         {
             UpdatePreviewPlaybackButtonContent();
+            UpdatePreviewPopOutButtonState();
         }
-    }
-
-    private void OnPreviewDetectionsChanged(object? sender, NotifyCollectionChangedEventArgs e)
-    {
-        RedrawPreviewOverlay();
-    }
-
-    private void OnPreviewFrameContainerSizeChanged(object sender, SizeChangedEventArgs e)
-    {
-        RedrawPreviewOverlay();
-    }
-
-    private void OnPreviewFrameImageOpened(object sender, RoutedEventArgs e)
-    {
-        RedrawPreviewOverlay();
-    }
-
-    private void OnPreviewFrameImageFailed(object sender, ExceptionRoutedEventArgs e)
-    {
-        PreviewOverlayCanvas.Children.Clear();
-        PreviewFrameImage.Source = null;
-        UpdatePreviewVisibility(hasImage: false);
     }
 
     private void OnTimelineColumnSplitterPointerPressed(object sender, PointerRoutedEventArgs e)
@@ -549,6 +514,31 @@ public sealed partial class MainPage : Page
         UpdatePreviewPlaybackButtonContent();
     }
 
+    private void OnPreviewPopOutClicked(object sender, RoutedEventArgs e)
+    {
+        if (_previewWindow is null)
+        {
+            _previewWindow = new PreviewWindow(ViewModel);
+            _previewWindow.Closed += OnPreviewWindowClosed;
+            _previewWindow.Activate();
+            SetPreviewDetachedState(isDetached: true);
+            return;
+        }
+
+        _previewWindow.Close();
+    }
+
+    private void OnPreviewWindowClosed(object sender, WindowEventArgs args)
+    {
+        if (_previewWindow is not null)
+        {
+            _previewWindow.Closed -= OnPreviewWindowClosed;
+            _previewWindow = null;
+        }
+
+        SetPreviewDetachedState(isDetached: false);
+    }
+
     private async void OnShowVersionInfoClicked(object sender, RoutedEventArgs e)
     {
         var assembly = typeof(App).Assembly;
@@ -558,7 +548,7 @@ public sealed partial class MainPage : Page
         var settingsPath = App.LaunchSettingsPath ?? "(not found)";
         var ocrDevice = Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_DEVICE") ?? "cpu";
         var ocrEngine = Environment.GetEnvironmentVariable("MOVIE_TELOP_OCR_ENGINE") ?? "paddleocr";
-        var message = $"アプリバージョン: {version}\nビルド出力: {AppContext.BaseDirectory}\n設定ファイル: {settingsPath}\nOCR device: {ocrDevice}\nOCR エンジン: {ocrEngine}";
+        var message = $"アプリバージョン: {version}`nビルド出力先: {AppContext.BaseDirectory}`n設定ファイル: {settingsPath}`nOCR device: {ocrDevice}`nOCR エンジン: {ocrEngine}";
 
         var dialog = new ContentDialog
         {
@@ -581,13 +571,13 @@ public sealed partial class MainPage : Page
     {
         var pythonPath = Environment.GetEnvironmentVariable("MOVIE_TELOP_PADDLEOCR_PYTHON");
         var licenseText = new StringBuilder()
-            .AppendLine("同梱または設定対象の主な構成:")
+            .AppendLine("組み込みまたは設定検出対象の主な依存:")
             .AppendLine("- Microsoft Windows App SDK 1.8.260416003")
             .AppendLine("- CommunityToolkit.Mvvm 8.4.2")
             .AppendLine("- OpenCvSharp4.Windows 4.13.0.20260302")
             .AppendLine("- PaddleOCR worker script (tools/ocr/paddle_ocr_worker.py)")
             .AppendLine()
-            .AppendLine("OCR runtime の想定:")
+            .AppendLine("OCR runtime の詳細")
             .AppendLine("- CPU: PaddlePaddle 3.2.0 + PaddleOCR 3.5.0")
             .AppendLine("- GPU: PaddlePaddle GPU 3.2.2 + PaddleOCR 3.5.0");
 
@@ -636,6 +626,26 @@ public sealed partial class MainPage : Page
         PreviewPlaybackButton.Content = _isPreviewPlaying
             ? ViewModel.UiText.PreviewPause
             : ViewModel.UiText.PreviewPlay;
+    }
+
+    private void UpdatePreviewPopOutButtonState()
+    {
+        var isDetached = _previewWindow is not null;
+        PreviewPopOutButton.Content = new FontIcon
+        {
+            Glyph = isDetached ? "\uE73E" : "\uE8A7"
+        };
+        ToolTipService.SetToolTip(PreviewPopOutButton, isDetached
+            ? "プレビューをメイン画面へ戻す"
+            : "プレビューを別画面で開く");
+    }
+
+    private void SetPreviewDetachedState(bool isDetached)
+    {
+        EmbeddedPreviewFrameView.Visibility = isDetached ? Visibility.Collapsed : Visibility.Visible;
+        PreviewDetachedStatePanel.Visibility = isDetached ? Visibility.Visible : Visibility.Collapsed;
+        CenterPaneColumn.Width = isDetached ? new GridLength(DetachedCenterPaneWidth) : new GridLength(1, GridUnitType.Star);
+        UpdatePreviewPopOutButtonState();
     }
 
     private void FocusTimelineEditingTextBox()
@@ -822,121 +832,4 @@ public sealed partial class MainPage : Page
         }
     }
 
-    private void UpdatePreviewImage()
-    {
-        var imagePath = ViewModel.PreviewImagePath;
-        if (string.IsNullOrWhiteSpace(imagePath) || !File.Exists(imagePath))
-        {
-            PreviewFrameImage.Source = null;
-            PreviewOverlayCanvas.Children.Clear();
-            UpdatePreviewVisibility(hasImage: false);
-            return;
-        }
-
-        PreviewFrameImage.Source = new BitmapImage(new System.Uri(System.IO.Path.GetFullPath(imagePath), UriKind.Absolute));
-        UpdatePreviewVisibility(hasImage: true);
-        RedrawPreviewOverlay();
-    }
-
-    private void UpdatePreviewVisibility(bool hasImage)
-    {
-        PreviewFrameImage.Visibility = hasImage ? Visibility.Visible : Visibility.Collapsed;
-        PreviewOverlayCanvas.Visibility = hasImage ? Visibility.Visible : Visibility.Collapsed;
-        PreviewEmptyState.Visibility = hasImage ? Visibility.Collapsed : Visibility.Visible;
-    }
-
-    private void RedrawPreviewOverlay()
-    {
-        PreviewOverlayCanvas.Children.Clear();
-
-        var sourceWidth = ViewModel.PreviewImageWidth;
-        var sourceHeight = ViewModel.PreviewImageHeight;
-        if (sourceWidth <= 0 || sourceHeight <= 0 || ViewModel.PreviewDetections.Count == 0)
-        {
-            return;
-        }
-
-        var containerWidth = PreviewFrameContainer.ActualWidth;
-        var containerHeight = PreviewFrameContainer.ActualHeight;
-        if (containerWidth <= 0 || containerHeight <= 0)
-        {
-            return;
-        }
-
-        PreviewOverlayCanvas.Width = containerWidth;
-        PreviewOverlayCanvas.Height = containerHeight;
-
-        var scale = Math.Min(containerWidth / sourceWidth, containerHeight / sourceHeight);
-        var displayWidth = sourceWidth * scale;
-        var displayHeight = sourceHeight * scale;
-        var offsetX = (containerWidth - displayWidth) / 2d;
-        var offsetY = (containerHeight - displayHeight) / 2d;
-
-        foreach (var detection in ViewModel.PreviewDetections)
-        {
-            DrawDetectionOverlay(detection, scale, offsetX, offsetY);
-        }
-    }
-
-    private void DrawDetectionOverlay(
-        PreviewDetectionOverlay detection,
-        double scale,
-        double offsetX,
-        double offsetY)
-    {
-        if (detection.BoundingBox.Count == 0)
-        {
-            return;
-        }
-
-        var strokeBrush = detection.IsHighlighted
-            ? new SolidColorBrush(Colors.OrangeRed)
-            : new SolidColorBrush(Colors.DeepSkyBlue);
-        var fillBrush = detection.IsHighlighted
-            ? new SolidColorBrush(ColorHelper.FromArgb(36, 255, 69, 0))
-            : new SolidColorBrush(ColorHelper.FromArgb(24, 0, 191, 255));
-
-        var polygon = new Polygon
-        {
-            Stroke = strokeBrush,
-            StrokeThickness = detection.IsHighlighted ? 3 : 2,
-            Fill = fillBrush,
-            Points = new PointCollection()
-        };
-
-        foreach (var point in detection.BoundingBox)
-        {
-            polygon.Points.Add(new Point(offsetX + (point.X * scale), offsetY + (point.Y * scale)));
-        }
-
-        PreviewOverlayCanvas.Children.Add(polygon);
-
-        var minX = detection.BoundingBox.Min(point => point.X);
-        var minY = detection.BoundingBox.Min(point => point.Y);
-        var label = new Border
-        {
-            Background = new SolidColorBrush(ColorHelper.FromArgb(224, 16, 16, 16)),
-            CornerRadius = new CornerRadius(4),
-            Padding = new Thickness(6, 2, 6, 3),
-            Child = new TextBlock
-            {
-                Foreground = new SolidColorBrush(Colors.White),
-                FontSize = 11,
-                Text = CreateDetectionLabel(detection),
-                TextTrimming = Microsoft.UI.Xaml.TextTrimming.CharacterEllipsis,
-                MaxWidth = 220
-            }
-        };
-
-        Canvas.SetLeft(label, offsetX + (minX * scale));
-        Canvas.SetTop(label, Math.Max(0, offsetY + (minY * scale) - 24));
-        PreviewOverlayCanvas.Children.Add(label);
-    }
-
-    private static string CreateDetectionLabel(PreviewDetectionOverlay detection)
-    {
-        return detection.Confidence is null
-            ? detection.Text
-            : $"{detection.Text} ({detection.Confidence:P0})";
-    }
 }

--- a/src/MovieTelopTranscriber.App/PreviewWindow.xaml.cs
+++ b/src/MovieTelopTranscriber.App/PreviewWindow.xaml.cs
@@ -1,0 +1,146 @@
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using MovieTelopTranscriber.App.Controls;
+using MovieTelopTranscriber.App.ViewModels;
+using Windows.Graphics;
+
+namespace MovieTelopTranscriber.App;
+
+public sealed class PreviewWindow : Window
+{
+    public PreviewWindow(MainPageViewModel viewModel)
+    {
+        ViewModel = viewModel;
+
+        Title = "Preview - Movie Telop Transcriber";
+        AppWindow.SetIcon("Assets/AppIcon.ico");
+        AppWindow.Resize(new SizeInt32(1120, 840));
+        if (AppWindow.Presenter is OverlappedPresenter presenter)
+        {
+            presenter.IsMinimizable = true;
+        }
+
+        var rootGrid = new Grid
+        {
+            Padding = new Thickness(16),
+            RowSpacing = 12
+        };
+        rootGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        rootGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+        rootGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+        var titleText = new TextBlock
+        {
+            Text = ViewModel.UiText.PreviewSection,
+            FontSize = 20,
+            FontWeight = new Windows.UI.Text.FontWeight { Weight = 600 }
+        };
+
+        var summaryText = new TextBlock
+        {
+            TextWrapping = TextWrapping.WrapWholeWords
+        };
+        summaryText.SetBinding(TextBlock.TextProperty, new Binding
+        {
+            Source = ViewModel,
+            Path = new PropertyPath(nameof(MainPageViewModel.SelectedSegmentSummary))
+        });
+
+        var detailText = new TextBlock
+        {
+            TextWrapping = TextWrapping.WrapWholeWords,
+            Opacity = 0.8
+        };
+        detailText.SetBinding(TextBlock.TextProperty, new Binding
+        {
+            Source = ViewModel,
+            Path = new PropertyPath(nameof(MainPageViewModel.PreviewDetailText))
+        });
+
+        var headerPanel = new StackPanel { Spacing = 4 };
+        headerPanel.Children.Add(titleText);
+        headerPanel.Children.Add(summaryText);
+        headerPanel.Children.Add(detailText);
+
+        var previewFrameView = new PreviewFrameView
+        {
+            EmptyCaptionText = ViewModel.UiText.PreviewShell,
+            FrameMinHeight = 560
+        };
+        previewFrameView.SetBinding(PreviewFrameView.ImagePathProperty, new Binding
+        {
+            Source = ViewModel,
+            Path = new PropertyPath(nameof(MainPageViewModel.PreviewImagePath))
+        });
+        previewFrameView.SetBinding(PreviewFrameView.SourceWidthProperty, new Binding
+        {
+            Source = ViewModel,
+            Path = new PropertyPath(nameof(MainPageViewModel.PreviewImageWidth))
+        });
+        previewFrameView.SetBinding(PreviewFrameView.SourceHeightProperty, new Binding
+        {
+            Source = ViewModel,
+            Path = new PropertyPath(nameof(MainPageViewModel.PreviewImageHeight))
+        });
+        previewFrameView.SetBinding(PreviewFrameView.DetectionsProperty, new Binding
+        {
+            Source = ViewModel,
+            Path = new PropertyPath(nameof(MainPageViewModel.PreviewDetections))
+        });
+        previewFrameView.SetBinding(PreviewFrameView.EmptyStateTextProperty, new Binding
+        {
+            Source = ViewModel,
+            Path = new PropertyPath(nameof(MainPageViewModel.PreviewState))
+        });
+
+        var footerGrid = new Grid { ColumnSpacing = 10 };
+        footerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        footerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var slider = new Slider { Minimum = 0 };
+        slider.SetBinding(Slider.MaximumProperty, new Binding
+        {
+            Source = ViewModel,
+            Path = new PropertyPath(nameof(MainPageViewModel.PreviewSequenceMaximum))
+        });
+        slider.SetBinding(Slider.IsEnabledProperty, new Binding
+        {
+            Source = ViewModel,
+            Path = new PropertyPath(nameof(MainPageViewModel.HasPreviewSequence))
+        });
+        slider.SetBinding(Slider.ValueProperty, new Binding
+        {
+            Source = ViewModel,
+            Path = new PropertyPath(nameof(MainPageViewModel.PreviewSequenceValue)),
+            Mode = BindingMode.TwoWay
+        });
+
+        var sequenceLabel = new TextBlock
+        {
+            MinWidth = 52,
+            VerticalAlignment = VerticalAlignment.Center,
+            TextAlignment = TextAlignment.Right
+        };
+        sequenceLabel.SetBinding(TextBlock.TextProperty, new Binding
+        {
+            Source = ViewModel,
+            Path = new PropertyPath(nameof(MainPageViewModel.PreviewSequenceLabel))
+        });
+
+        footerGrid.Children.Add(slider);
+        Grid.SetColumn(sequenceLabel, 1);
+        footerGrid.Children.Add(sequenceLabel);
+
+        rootGrid.Children.Add(headerPanel);
+        Grid.SetRow(previewFrameView, 1);
+        rootGrid.Children.Add(previewFrameView);
+        Grid.SetRow(footerGrid, 2);
+        rootGrid.Children.Add(footerGrid);
+
+        Content = rootGrid;
+    }
+
+    public MainPageViewModel ViewModel { get; }
+}

--- a/src/MovieTelopTranscriber.App/Services/MainWindowLayoutStore.cs
+++ b/src/MovieTelopTranscriber.App/Services/MainWindowLayoutStore.cs
@@ -5,7 +5,7 @@ namespace MovieTelopTranscriber.App.Services;
 
 internal static class MainWindowLayoutStore
 {
-    private const int DefaultWidth = 1820;
+    private const int DefaultWidth = 1800;
     private const int DefaultHeight = 1080;
     private const int MinimumWidth = 1560;
     private const int MinimumHeight = 920;

--- a/src/MovieTelopTranscriber.App/SettingsWindow.xaml
+++ b/src/MovieTelopTranscriber.App/SettingsWindow.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <Window
     x:Class="MovieTelopTranscriber.App.SettingsWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -102,7 +102,7 @@
                             IsEnabled="{x:Bind ViewModel.CanInteract, Mode=OneWay}"
                             ItemsSource="{x:Bind ViewModel.PaddleDeviceOptions, Mode=OneWay}"
                             SelectedItem="{x:Bind ViewModel.SelectedPaddleDeviceOption, Mode=TwoWay}"
-                            ToolTipService.ToolTip="cpu または gpu:0 を選びます。GPU を使うには、この PC に GPU 対応の Paddle runtime が入っている必要があります。">
+                            ToolTipService.ToolTip="cpu または gpu:0 を選べます。GPU を使うには、この PC に GPU 対応の Paddle runtime が入っている必要があります。">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate x:DataType="models:SelectionOption">
                                     <TextBlock Text="{x:Bind DisplayName}" />

--- a/src/MovieTelopTranscriber.App/SettingsWindow.xaml.cs
+++ b/src/MovieTelopTranscriber.App/SettingsWindow.xaml.cs
@@ -14,7 +14,7 @@ public sealed partial class SettingsWindow : Window
 
         Title = "Settings - Movie Telop Transcriber";
         AppWindow.SetIcon("Assets/AppIcon.ico");
-        AppWindow.Resize(new SizeInt32(1480, 930));
+        AppWindow.Resize(new SizeInt32(1480, 950));
         if (AppWindow.Presenter is OverlappedPresenter presenter)
         {
             presenter.IsResizable = false;


### PR DESCRIPTION
﻿## 概要
- 設定画面高さを 950px に拡張
- 右ペイン最低幅と初回起動幅を再調整
- プレビューの別画面ポップアップ機能を追加
- ポップアップ表示中は中央ペインを最小幅寄りへ切り替え
- ヘルプ / GPU ツールチップ周辺の文字化け文字列を正常化

## 検証
- dotnet build .\src\MovieTelopTranscriber.sln -c Release -p:Platform=x64
- git diff --check
- Release build の EXE 起動確認
